### PR TITLE
Fix Pulse.volume_get_all_chans to return float value

### DIFF
--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -481,7 +481,7 @@ class Pulse(object):
 
 	def volume_get_all_chans(self, obj):
 		assert isinstance(obj, PulseObject), [type(obj), obj]
-		return int(sum(obj.volume.values) / len(obj.volume.values))
+		return sum(obj.volume.values) / len(obj.volume.values)
 
 
 	def event_mask_set(self, *masks):


### PR DESCRIPTION
Tested on Ubuntu 16.04 beta2 (64bit) with Python 2.7.11, a `Pulse` object will return either `0` or `1` for `volume_get_all_chans()` call, this was because you turned the result into `int` type, and the actual volume range is a `float` type ranging from 0 to 1.