### PR TITLE
Update pulsectl.py

### DIFF
--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -470,6 +470,8 @@ class Pulse(object):
 
 	def volume_set(self, obj, vol):
 		assert isinstance(obj, PulseObject), [type(obj), obj]
+		obj.volume.values = [v if v > 0.0 else 0.0 for v in obj.volume.values]
+		obj.volume.values = [v if v < 1.0 else 1.0 for v in obj.volume.values]
 		method = {
 			PulseSinkInfo: self.sink_volume_set,
 			PulseSinkInputInfo: self.sink_input_volume_set,


### PR DESCRIPTION
When I tried to use the volume_change_all_chans, I did not check if the volume of all channels was greater than the increment. This resulted in the code trying to set a negative value for the volume. It made the whole script crash without any real error message.
Thus, to avoid that it might be interesting to make sure that all your values are within the correct range.
I know that 0.0 is the minimum, but i am unsure about 1.0 being the maximum. You might be able to set a higher value than one resulting in a soft-boost.