### PR TITLE
connect_to_cli: Keep socket open on as_file=False

### DIFF
--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -862,4 +862,4 @@ def connect_to_cli(server=None, as_file=True, socket_timeout=1.0, attempts=5, re
 			' cli socket {!r}: {} {}'.format(server, type(err), err) )
 
 	finally:
-		if s: s.close()
+		if s and as_file: s.close()


### PR DESCRIPTION
Hi

When calling `connect_to_cli()` with `as_file=False`, the function returns a closed socket. Simple way to test this (with Python 3.5):

```python
s = pulsectl.connect_to_cli(server="/run/user/1000/pulse/cli", as_file=False)
print(s)
# <socket.socket [closed] fd=-1, family=AddressFamily.AF_UNIX, type=2049, proto=0>
```

The problem is that the `finally` clause closes the socket before the function returns. Since a closed socket isn't very useful, this pull request fixes the `finally` clause so that the socket remains opened when `as_file=False`. In this case it is up to the caller to close the socket after use.