### PR TITLE
Fix hang if PulseAudio daemon dies

### DIFF
--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -467,7 +467,7 @@ class Pulse(object):
 			cb = lambda s=True,k=act_id: self._actions.update({k: bool(s)})
 			if not raw: cb = c.PA_CONTEXT_SUCCESS_CB_T(lambda ctx,s,d,cb=cb: cb(s))
 			yield cb
-			while self._actions[act_id] is None: self._pulse_iterate()
+			while not self._loop_stop and self._actions[act_id] is None: self._pulse_iterate()
 			if not self._actions[act_id]: raise PulseOperationFailed(act_id)
 		finally: self._actions.pop(act_id, None)
 


### PR DESCRIPTION
Hi

I've noticed that `sink_list()` method hangs indefinitely without an error if PulseAudio daemon crashes or is restarted after the `Pulse` object is created. I believe the correct behavior would be for the method to raise an exception.

To reproduce:

```python
import pulsectl
import sys

pulse = pulsectl.Pulse('test')
print('restart pulseaudio and press enter')
sys.stdin.readline()
print('query')
for l in pulse.sink_list():
    print(l)
```

With existing pulsectl, the `sink_list()` call hangs. With the patch in this pull request, it raises `pulsectl.pulsectl.PulseOperationFailed`.

`_pulse_state_cb()` already detects that the daemon disconnected after the first
`pa_mainloop_iterate()` and sets `_loop_stop`. This change only makes the `_pulse_op_cb`
honor `_loop_stop` and prevents subsequent `pa_mainloop_iterate()` calls.