### PR TITLE
Added missing attribute pa_client_info.proplist

### DIFF
--- a/pulsectl/_pulsectl.py
+++ b/pulsectl/_pulsectl.py
@@ -264,6 +264,7 @@ class PA_CLIENT_INFO(Structure):
 		('name', c_char_p),
 		('owner_module', c_uint32),
 		('driver', c_char_p),
+		('proplist', POINTER(PA_PROPLIST)),
 	]
 
 class PA_SERVER_INFO(Structure):


### PR DESCRIPTION
I noticed that the attribute "proplist" was missing for PulseClientInfo (see libpulse docs at https://freedesktop.org/software/pulseaudio/doxygen/structpa__client__info.html). I added the mapping and it worked for me.