### PR TITLE
Implement sample play command

### DIFF
--- a/pulsectl/_pulsectl.py
+++ b/pulsectl/_pulsectl.py
@@ -612,7 +612,9 @@ class LibPulse(object):
 		pa_stream_peek=(
 			[POINTER(PA_STREAM), POINTER(c_void_p), POINTER(c_int)], 'int_check_ge0' ),
 		pa_stream_drop=([POINTER(PA_STREAM)], 'int_check_ge0'),
-		pa_stream_disconnect=([POINTER(PA_STREAM)], 'int_check_ge0') )
+		pa_stream_disconnect=([POINTER(PA_STREAM)], 'int_check_ge0'),
+		pa_context_play_sample=( 'pa_op',
+			[POINTER(PA_CONTEXT), c_str_p, c_str_p, c_uint32, PA_CONTEXT_SUCCESS_CB_T, c_void_p]) )
 
 	class CallError(Exception): pass
 

--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -876,6 +876,14 @@ class Pulse(object):
 
 		return min(1.0, samples[0])
 
+	_play_sample = _pulse_method_call(
+		c.pa.context_play_sample, func=lambda name, dev: [name, dev, c.PA_VOLUME_NORM], index_arg=False)
+
+	def play_sample(self, sample_name, sink):
+		if isinstance(sink, PulseSinkInfo):
+			sink = sink.name
+		self._play_sample(sample_name, sink)
+
 
 def connect_to_cli(server=None, as_file=True, socket_timeout=1.0, attempts=5, retry_delay=0.3):
 	'''Returns connected CLI interface socket (as file object, unless as_file=False),


### PR DESCRIPTION
This exposes the c api command [`pa_context_play_sample`](https://freedesktop.org/software/pulseaudio/doxygen/scache_8h.html#adb1bf81ecef03f8bae77e5e3ab30464f) from the library

the volume parameter is actually different than in other commands so I decided to always pass "keep volume".