### PR TITLE
Allow sink proplists to be edited

### DIFF
--- a/pulsectl/_pulsectl.py
+++ b/pulsectl/_pulsectl.py
@@ -562,6 +562,8 @@ class LibPulse(object):
 			[POINTER(PA_CONTEXT), c_uint32, PA_CLIENT_INFO_CB_T, c_void_p] ),
 		pa_context_get_server_info=( 'pa_op',
 			[POINTER(PA_CONTEXT), PA_SERVER_INFO_CB_T, c_void_p] ),
+		pa_context_proplist_update=('pa_op',
+			[POINTER(PA_CONTEXT), c_int, POINTER(PA_PROPLIST), PA_CONTEXT_SUCCESS_CB_T, c_void_p]),
 		pa_operation_unref=[POINTER(PA_OPERATION)],
 		pa_context_get_card_info_by_index=( 'pa_op',
 			[POINTER(PA_CONTEXT), c_uint32, PA_CARD_INFO_CB_T, c_void_p] ),
@@ -592,8 +594,9 @@ class LibPulse(object):
 			[POINTER(PA_CONTEXT), POINTER(c_char_p), PA_CONTEXT_SUCCESS_CB_T, c_void_p] ),
 		pa_context_set_subscribe_callback=[POINTER(PA_CONTEXT), PA_SUBSCRIBE_CB_T, c_void_p],
 		pa_proplist_iterate=([POINTER(PA_PROPLIST), POINTER(c_void_p)], c_str_p),
+		pa_proplist_new=(POINTER(PA_PROPLIST)),
 		pa_proplist_gets=([POINTER(PA_PROPLIST), c_str_p], c_str_p),
-		pa_proplist_sets=([POINTER(PA_PROPLIST), c_char_p, c_char_p], c_int),
+		pa_proplist_sets=([POINTER(PA_PROPLIST), c_str_p, c_str_p], c_int),
 		pa_channel_map_init_mono=(
 			[POINTER(PA_CHANNEL_MAP)], (POINTER(PA_CHANNEL_MAP), 'not_null') ),
 		pa_channel_map_init_stereo=(

--- a/pulsectl/_pulsectl.py
+++ b/pulsectl/_pulsectl.py
@@ -593,6 +593,7 @@ class LibPulse(object):
 		pa_context_set_subscribe_callback=[POINTER(PA_CONTEXT), PA_SUBSCRIBE_CB_T, c_void_p],
 		pa_proplist_iterate=([POINTER(PA_PROPLIST), POINTER(c_void_p)], c_str_p),
 		pa_proplist_gets=([POINTER(PA_PROPLIST), c_str_p], c_str_p),
+		pa_proplist_sets=([POINTER(PA_PROPLIST), c_char_p, c_char_p], c_int),
 		pa_channel_map_init_mono=(
 			[POINTER(PA_CHANNEL_MAP)], (POINTER(PA_CHANNEL_MAP), 'not_null') ),
 		pa_channel_map_init_stereo=(

--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -125,6 +125,7 @@ class PulseObject(object):
 					k = c.pa.proplist_iterate(struct.proplist, c.byref(state))
 					if not k: break
 					self.proplist[c.force_str(k)] = c.force_str(c.pa.proplist_gets(struct.proplist, k))
+					self.proplist_pointer = struct.proplist
 			if hasattr(struct, 'volume'):
 				self.volume = self._get_wrapper(PulseVolumeInfo)(struct.volume)
 			if hasattr(struct, 'n_ports'):
@@ -657,6 +658,11 @@ class Pulse(object):
 		return index
 
 	module_unload = _pulse_method_call(c.pa.context_unload_module, None)
+
+	def proplist_set(self, pulse_info, key, value):
+		assert_pulse_object(pulse_info)
+		key, value = map(c.force_bytes, [key, value])
+		c.pa.proplist_sets(pulse_info.proplist_pointer, key, value)
 
 
 	def stream_restore_test(self):

--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -125,7 +125,6 @@ class PulseObject(object):
 					k = c.pa.proplist_iterate(struct.proplist, c.byref(state))
 					if not k: break
 					self.proplist[c.force_str(k)] = c.force_str(c.pa.proplist_gets(struct.proplist, k))
-					self.proplist_pointer = struct.proplist
 			if hasattr(struct, 'volume'):
 				self.volume = self._get_wrapper(PulseVolumeInfo)(struct.volume)
 			if hasattr(struct, 'n_ports'):
@@ -660,9 +659,9 @@ class Pulse(object):
 	module_unload = _pulse_method_call(c.pa.context_unload_module, None)
 
 	def proplist_set(self, pulse_info, key, value):
-		assert_pulse_object(pulse_info)
-		key, value = map(c.force_bytes, [key, value])
-		c.pa.proplist_sets(pulse_info.proplist_pointer, key, value)
+		proplist = c.pa.proplist_new()
+		c.pa.proplist_sets(proplist, key, value)
+		self._pulse_method_call(c.pa.context_proplist_update, lambda unsure: unsure)(pulse_info, 2, proplist)
 
 
 	def stream_restore_test(self):

--- a/scratch.py
+++ b/scratch.py
@@ -1,0 +1,8 @@
+import sys
+from pulsectl import pulsectl
+
+pulse = pulsectl.Pulse('t')
+
+
+print("test")
+sys.settrace(pulse.proplist_set(next(filter(lambda x: x.description == 'MySink', pulse.source_list())), "description", "test"))


### PR DESCRIPTION
At the moment, once you have a proplist for a certain device, you're unable to edit it. It would benefit my use-case to be able to rename a sink associated with a loaded module, so this PR adds the new required calls to enable that functionality.