### PR TITLE
Asyncio Integration

### DIFF
--- a/pulsectl/__init__.py
+++ b/pulsectl/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
+import sys
+
 from . import _pulsectl
 
 from .pulsectl import (
@@ -15,4 +17,5 @@ from .pulsectl import (
 	PulseError, PulseIndexError, PulseOperationFailed, PulseOperationInvalid,
 	PulseLoopStop, PulseDisconnected, PulseObject, Pulse, connect_to_cli )
 
-from .pulsectl_async import PulseAsync
+if sys.version_info.major >= 3:
+	from .pulsectl_async import PulseAsync

--- a/pulsectl/__init__.py
+++ b/pulsectl/__init__.py
@@ -14,3 +14,5 @@ from .pulsectl import (
 
 	PulseError, PulseIndexError, PulseOperationFailed, PulseOperationInvalid,
 	PulseLoopStop, PulseDisconnected, PulseObject, Pulse, connect_to_cli )
+
+from .pulsectl_async import PulseAsync

--- a/pulsectl/__init__.py
+++ b/pulsectl/__init__.py
@@ -17,5 +17,5 @@ from .pulsectl import (
 	PulseError, PulseIndexError, PulseOperationFailed, PulseOperationInvalid,
 	PulseLoopStop, PulseDisconnected, PulseObject, Pulse, connect_to_cli )
 
-if sys.version_info.major >= 3:
+if sys.version_info >= (3, 6):
 	from .pulsectl_async import PulseAsync

--- a/pulsectl/pa_asyncio_mainloop.py
+++ b/pulsectl/pa_asyncio_mainloop.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) 2021 Michael Thies
+#
+
 import asyncio
 import ctypes as c
 import enum

--- a/pulsectl/pa_asyncio_mainloop.py
+++ b/pulsectl/pa_asyncio_mainloop.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+import asyncio
+import ctypes as c
+import enum
+import time
+from functools import partial
+from typing import Set, Optional, Dict
+from pulsectl._pulsectl import PA_MAINLOOP_API
+
+# References:
+# - https://docs.python.org/3.9/library/ctypes.html
+# - https://freedesktop.org/software/pulseaudio/doxygen/mainloop-api_8h.html
+
+
+class pa_mainloop_api(PA_MAINLOOP_API):
+    pass
+
+
+class timeval(c.Structure):
+    _fields_ = [
+        ('tv_sec', c.c_longlong),
+        ('tv_usec', c.c_long),
+    ]
+
+    def to_float(self) -> float:
+        return self.tv_sec + self.tv_usec / 1e6
+
+
+PA_IO_EVENT_NULL = 0
+PA_IO_EVENT_INPUT = 1
+PA_IO_EVENT_OUTPUT = 2
+PA_IO_EVENT_HANGUP = 4
+PA_IO_EVENT_ERROR = 8
+
+# Typedefs from mainloop.h
+pa_defer_event_p = c.c_void_p
+pa_defer_event_cb_t = c.CFUNCTYPE(None, c.POINTER(pa_mainloop_api), pa_defer_event_p, c.c_void_p)
+pa_defer_event_destroy_cb_t = c.CFUNCTYPE(None, c.POINTER(pa_mainloop_api), pa_defer_event_p, c.c_void_p)
+pa_io_event_p = c.c_void_p
+pa_io_event_flags = c.c_int
+pa_io_event_cb_t = c.CFUNCTYPE(None, c.POINTER(pa_mainloop_api), pa_io_event_p, c.c_int, pa_io_event_flags, c.c_void_p)
+pa_io_event_destroy_cb_t = c.CFUNCTYPE(None, c.POINTER(pa_mainloop_api), pa_io_event_p, c.c_void_p)
+pa_time_event_p = c.c_void_p
+pa_time_event_cb_t = c.CFUNCTYPE(None, c.POINTER(pa_mainloop_api), pa_time_event_p, c.POINTER(timeval), c.c_void_p)
+pa_time_event_destroy_cb_t = c.CFUNCTYPE(None, c.POINTER(pa_mainloop_api), pa_time_event_p, c.c_void_p)
+
+# function pointer types of pa_mainloop_api struct
+pa_io_new_t = c.CFUNCTYPE(pa_io_event_p, c.POINTER(pa_mainloop_api), c.c_int, pa_io_event_flags, pa_io_event_cb_t,
+                          c.c_void_p)
+pa_io_enable_t = c.CFUNCTYPE(None, pa_io_event_p, pa_io_event_flags)
+pa_io_set_destroy_t = c.CFUNCTYPE(None, pa_io_event_p, pa_io_event_destroy_cb_t)
+pa_io_free_t = c.CFUNCTYPE(None, pa_io_event_p)
+pa_time_new_t = c.CFUNCTYPE(pa_time_event_p, c.POINTER(pa_mainloop_api), c.POINTER(timeval), pa_time_event_cb_t,
+                            c.c_void_p)
+pa_time_restart_t = c.CFUNCTYPE(None, pa_time_event_p, c.POINTER(timeval))
+pa_time_set_destroy_t = c.CFUNCTYPE(None, pa_time_event_p, pa_time_event_destroy_cb_t)
+pa_time_free_t = c.CFUNCTYPE(None, pa_time_event_p)
+pa_defer_new_t = c.CFUNCTYPE(pa_defer_event_p, c.POINTER(pa_mainloop_api), pa_defer_event_cb_t, c.c_void_p)
+pa_defer_enable_t = c.CFUNCTYPE(None, pa_defer_event_p, c.c_bool)
+pa_defer_free_t = c.CFUNCTYPE(None, pa_defer_event_p)
+pa_defer_set_destroy_t = c.CFUNCTYPE(None, pa_defer_event_p, pa_defer_event_destroy_cb_t)
+
+pa_mainloop_api._fields_ = [
+    ("userdata", c.c_void_p),  # We use it to store a pointer to the corresponding PythonMainLoop python object
+    ("io_new", pa_io_new_t),
+    ("io_enable", pa_io_enable_t),
+    ("io_free", pa_io_free_t),
+    ("io_set_destroy", pa_io_set_destroy_t),
+    ("time_new", pa_time_new_t),
+    ("time_restart", pa_time_restart_t),
+    ("time_free", pa_time_free_t),
+    ("time_set_destroy", pa_time_set_destroy_t),
+    ("defer_new", pa_defer_new_t),
+    ("defer_enable", pa_defer_enable_t),
+    ("defer_free", pa_defer_free_t),
+    ("defer_set_destroy", pa_defer_set_destroy_t),
+    ("quit", c.CFUNCTYPE(None, c.POINTER(pa_mainloop_api), c.c_int)),
+]
+
+
+class PythonMainLoop:
+    __slots__ = ('loop', 'io_events', 'time_events', 'defer_events', 'num_enabled_defer_events', 'wakeup_defer_events',
+                 'api_pointer', 'io_reader_events', 'io_writer_events')
+
+    def __init__(self, loop: asyncio.AbstractEventLoop):
+        self.loop = loop
+        self.io_events: Set["PythonIOEvent"] = set()
+        self.defer_events: Set["PythonDeferEvent"] = set()
+        self.time_events: Set["PythonTimeEvent"] = set()
+        self.io_reader_events: Dict[int, Set[PythonIOEvent]] = {}
+        self.io_writer_events: Dict[int, Set[PythonIOEvent]] = {}
+        self.num_enabled_defer_events: int = 0
+        self.wakeup_defer_events = asyncio.Event()
+        self.api_pointer = c.pointer(self._create_api())
+        loop.create_task(self._deferred_events_task())
+
+    def _create_api(self) -> pa_mainloop_api:
+        result = pa_mainloop_api()
+        result.userdata = c.cast(c.pointer(c.py_object(self)), c.c_void_p)
+        result.io_new = aio_io_new
+        result.io_enable = aio_io_enable
+        result.io_free = aio_io_free
+        result.io_set_destroy = aio_io_set_destroy
+        result.time_new = aio_time_new
+        result.time_restart = aio_time_restart
+        result.time_free = aio_time_free
+        result.time_set_destroy = aio_time_set_destroy
+        result.defer_new = aio_defer_new
+        result.defer_enable = aio_defer_enable
+        result.defer_free = aio_defer_free
+        result.defer_set_destroy = aio_defer_set_destroy
+        # TODO quit method
+        return result
+
+    async def _deferred_events_task(self) -> None:
+        try:
+            while True:
+                for event in tuple(self.defer_events):
+                    if event.enabled:
+                        event.call()
+                if self.num_enabled_defer_events:
+                    await asyncio.sleep(0)
+                else:
+                    self.wakeup_defer_events.clear()
+                    await self.wakeup_defer_events.wait()
+        except asyncio.CancelledError:
+            pass
+
+    def register_unregister_io_event(self, event: "PythonIOEvent", reader: bool, writer: bool) -> None:
+        if writer:
+            if event.fd in self.io_writer_events:
+                self.io_writer_events[event.fd].add(event)
+            else:
+                self.io_writer_events[event.fd] = {event}
+                self.loop.add_writer(event.fd, partial(self._io_write_callback, event.fd))
+        elif event.fd in self.io_writer_events:
+            self.io_writer_events[event.fd].discard(event)
+            if not self.io_writer_events[event.fd]:
+                del self.io_writer_events[event.fd]
+                self.loop.remove_writer(event.fd)
+
+        if reader:
+            if event.fd in self.io_reader_events:
+                self.io_reader_events[event.fd].add(event)
+            else:
+                self.io_reader_events[event.fd] = {event}
+                self.loop.add_reader(event.fd, partial(self._io_read_callback, event.fd))
+        elif event.fd in self.io_reader_events:
+            self.io_reader_events[event.fd].discard(event)
+            if not self.io_reader_events[event.fd]:
+                del self.io_reader_events[event.fd]
+                self.loop.remove_reader(event.fd)
+        # Python asyncio's API does not allow us to `poll` for HANGUP and ERROR states.
+        # However, this does not seem to be an issue, since the pulse client library obviously does not use these flags
+        # for io io_events.
+
+    def _io_write_callback(self, fd) -> None:
+        for event in tuple(self.io_writer_events.get(fd, ())):
+            event.write()
+
+    def _io_read_callback(self, fd) -> None:
+        for event in tuple(self.io_reader_events.get(fd, ())):
+            event.read()
+
+
+class PythonIOEvent:
+    __slots__ = ('python_main_loop', 'fd', 'callback', 'userdata', 'on_destroy_callback', 'writer', 'reader',
+                 'self_pointer')
+
+    def __init__(self, python_main_loop: PythonMainLoop, fd: int, callback: pa_io_event_cb_t,
+                 userdata: c.c_void_p) -> None:
+        self.python_main_loop = python_main_loop
+        self.fd = fd
+        self.callback = callback
+        self.userdata = userdata
+        self.on_destroy_callback: Optional[pa_io_event_destroy_cb_t] = None
+        self.writer = False
+        self.reader = False
+        self.self_pointer: pa_io_event_p = c.cast(c.pointer(c.py_object(self)), pa_io_event_p)
+        python_main_loop.io_events.add(self)
+
+    def read(self) -> None:
+        self.callback(self.python_main_loop.api_pointer, self.self_pointer.value, self.fd, PA_IO_EVENT_INPUT,
+                      self.userdata)
+
+    def write(self) -> None:
+        self.callback(self.python_main_loop.api_pointer, self.self_pointer.value, self.fd, PA_IO_EVENT_OUTPUT,
+                      self.userdata)
+
+    def free(self) -> None:
+        self.python_main_loop.register_unregister_io_event(self, False, False)
+        if self.on_destroy_callback is not None:
+            self.on_destroy_callback(self.python_main_loop.api_pointer, c.pointer(c.py_object(self)), self.userdata)
+        self.python_main_loop.io_events.discard(self)
+
+    def set_destroy(self, callback: pa_io_event_destroy_cb_t) -> None:
+        self.on_destroy_callback = callback
+
+
+class PythonTimeEvent:
+    __slots__ = ('python_main_loop', 'callback', 'userdata', 'on_destroy_callback', 'handle', 'self_pointer')
+
+    def __init__(self, python_main_loop: PythonMainLoop, callback: pa_time_event_cb_t, userdata: c.c_void_p) -> None:
+        self.python_main_loop = python_main_loop
+        self.callback = callback
+        self.userdata = userdata
+        self.on_destroy_callback: Optional[pa_io_event_destroy_cb_t] = None
+        self.handle: Optional[asyncio.TimerHandle] = None
+        self.self_pointer: pa_io_event_p = c.cast(c.pointer(c.py_object(self)), pa_io_event_p)
+        python_main_loop.time_events.add(self)
+
+    def restart(self, ts: timeval) -> None:
+        if self.handle is not None:
+            self.handle.cancel()
+        self.handle = self.python_main_loop.loop.call_later(
+            ts.to_float() - time.time(), self.callback, self.python_main_loop.api_pointer, self.self_pointer.value,
+            ts, self.userdata)
+
+    def free(self) -> None:
+        if self.on_destroy_callback is not None:
+            self.on_destroy_callback(self.python_main_loop.api_pointer, c.pointer(c.py_object(self)), self.userdata)
+        if self.handle:
+            self.handle.cancel()
+        self.python_main_loop.time_events.discard(self)
+
+    def set_destroy(self, callback: pa_io_event_destroy_cb_t) -> None:
+        self.on_destroy_callback = callback
+
+
+class PythonDeferEvent:
+    __slots__ = ('python_main_loop', 'callback', 'userdata', 'on_destroy_callback', 'enabled', 'self_pointer')
+
+    def __init__(self, python_main_loop: PythonMainLoop, callback: pa_defer_event_cb_t, userdata: c.c_void_p) -> None:
+        self.python_main_loop = python_main_loop
+        self.callback = callback
+        self.userdata = userdata
+        self.on_destroy_callback: Optional[pa_io_event_destroy_cb_t] = None
+        self.enabled = False
+        self.self_pointer: pa_defer_event_p = c.cast(c.pointer(c.py_object(self)), pa_defer_event_p)
+        python_main_loop.defer_events.add(self)
+
+    def call(self) -> None:
+        self.callback(self.python_main_loop.api_pointer, self.self_pointer.value, self.userdata)
+
+    def enable(self, enable: bool) -> None:
+        if enable and not self.enabled:
+            self.python_main_loop.num_enabled_defer_events += 1
+            self.python_main_loop.wakeup_defer_events.set()
+        elif not enable and self.enabled:
+            self.python_main_loop.num_enabled_defer_events -= 1
+        self.enabled = enable
+
+    def free(self) -> None:
+        if self.on_destroy_callback is not None:
+            self.on_destroy_callback(self.python_main_loop.api_pointer, c.pointer(c.py_object(self)), self.userdata)
+        if self.enabled:
+            self.python_main_loop.num_enabled_defer_events -= 1
+        self.python_main_loop.defer_events.discard(self)
+
+    def set_destroy(self, callback: pa_io_event_destroy_cb_t) -> None:
+        self.on_destroy_callback = callback
+
+
+@pa_io_new_t
+def aio_io_new(main_loop: c.POINTER(pa_mainloop_api), fd: int, flags: int, cb: pa_io_event_cb_t,
+               userdata: c.c_void_p) -> int:
+    python_main_loop: PythonMainLoop = c.cast(main_loop.contents.userdata, c.POINTER(c.py_object)).contents.value
+
+    event = PythonIOEvent(python_main_loop, fd, cb, userdata)
+
+    reader = bool(flags & PA_IO_EVENT_INPUT)
+    writer = bool(flags & PA_IO_EVENT_OUTPUT)
+    python_main_loop.register_unregister_io_event(event, reader, writer)
+    return c.cast(event.self_pointer, pa_io_event_p).value
+
+
+@pa_io_enable_t
+def aio_io_enable(e: pa_io_event_p, flags: int) -> None:
+    event: PythonIOEvent = c.cast(e, c.POINTER(c.py_object)).contents.value
+
+    reader = bool(flags & PA_IO_EVENT_INPUT)
+    writer = bool(flags & PA_IO_EVENT_OUTPUT)
+    event.python_main_loop.register_unregister_io_event(event, reader, writer)
+
+
+@pa_io_set_destroy_t
+def aio_io_set_destroy(e: pa_io_event_p, cb: pa_io_event_destroy_cb_t) -> None:
+    event: PythonIOEvent = c.cast(e, c.POINTER(c.py_object)).contents.value
+    event.set_destroy(cb)
+
+
+@pa_io_free_t
+def aio_io_free(e: pa_io_event_p) -> None:
+    event: PythonIOEvent = c.cast(e, c.POINTER(c.py_object)).contents.value
+    event.free()
+
+
+@pa_time_new_t
+def aio_time_new(main_loop: c.POINTER(pa_mainloop_api), ts: c.POINTER(timeval), cb: pa_io_event_cb_t,
+                 userdata: c.c_void_p) -> int:
+    python_main_loop: PythonMainLoop = c.cast(main_loop.contents.userdata, c.POINTER(c.py_object)).contents.value
+    event = PythonTimeEvent(python_main_loop, cb, userdata)
+    event.restart(ts.contents)
+    return c.cast(event.self_pointer, pa_time_event_p).value
+
+
+@pa_time_restart_t
+def aio_time_restart(e: pa_time_event_p, ts: c.POINTER(timeval)) -> None:
+    event: PythonTimeEvent = c.cast(e, c.POINTER(c.py_object)).contents.value
+    event.restart(ts.contents)
+
+
+@pa_time_set_destroy_t
+def aio_time_set_destroy(e: pa_time_event_p, cb: pa_time_event_destroy_cb_t) -> None:
+    event: PythonTimeEvent = c.cast(e, c.POINTER(c.py_object)).contents.value
+    event.set_destroy(cb)
+
+
+@pa_time_free_t
+def aio_time_free(e: pa_io_event_p) -> None:
+    event: PythonTimeEvent = c.cast(e, c.POINTER(c.py_object)).contents.value
+    event.free()
+
+
+@pa_defer_new_t
+def aio_defer_new(main_loop: c.POINTER(pa_mainloop_api), cb: pa_defer_event_cb_t, userdata: c.c_void_p) -> int:
+    python_main_loop: PythonMainLoop = c.cast(main_loop.contents.userdata, c.POINTER(c.py_object)).contents.value
+    event = PythonDeferEvent(python_main_loop, cb, userdata)
+    event.enable(True)
+    return event.self_pointer.value
+
+
+@pa_defer_enable_t
+def aio_defer_enable(e: pa_defer_event_p, enable: bool) -> None:
+    event: PythonDeferEvent = c.cast(e, c.POINTER(c.py_object)).contents.value
+    event.enable(enable)
+
+
+@pa_defer_set_destroy_t
+def aio_defer_set_destroy(e: pa_defer_event_p, cb: pa_defer_event_destroy_cb_t) -> None:
+    event: PythonDeferEvent = c.cast(e, c.POINTER(c.py_object)).contents.value
+    event.set_destroy(cb)
+
+
+@pa_defer_free_t
+def aio_defer_free(e: pa_io_event_p) -> None:
+    event: PythonDeferEvent = c.cast(e, c.POINTER(c.py_object)).contents.value
+    event.free()

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -124,7 +124,7 @@ class PulseAsync(object):
 			elif state in [c.PA_CONTEXT_FAILED, c.PA_CONTEXT_TERMINATED]:
 				self.connected.clear()
 				self.disconnected.set()
-				for future in self._actions:
+				for future in self._actions.values():
 					future.set_exception(PulseDisconnected())
 
 	def _pulse_subscribe_cb(self, ctx, ev, idx, userdata):

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -128,7 +128,6 @@ class PulseAsync(object):
 		self._actions[act_id] = self._loop.loop.create_future()
 		try:
 			def cb (s=True,k=act_id):
-				print(f"Set future for action {act_id} ({s})")
 				if s: self._loop.loop.call_soon_threadsafe(self._actions[k].set_result, None)
 				else: self._loop.loop.call_soon_threadsafe(self._actions[k].set_exception, PulseOperationFailed(act_id))
 			if not raw: cb = c.PA_CONTEXT_SUCCESS_CB_T(lambda ctx,s,d,cb=cb: cb(s))

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -106,8 +106,9 @@ class PulseAsync(object):
 		self.close()
 
 	async def _wait_disconnect_or(self, coroutine: Coroutine):
-		wait_disconnected = asyncio.create_task(self._disconnected.wait())
-		other_task = asyncio.create_task(coroutine)
+		loop = asyncio.get_event_loop()
+		wait_disconnected = loop.create_task(self._disconnected.wait())
+		other_task = loop.create_task(coroutine)
 		done, pending = await asyncio.wait((wait_disconnected, other_task), return_when=asyncio.FIRST_COMPLETED)
 		for task in pending:
 			task.cancel()
@@ -437,7 +438,7 @@ class PulseAsync(object):
 	async def subscribe_events(self, *masks) -> AsyncIterator[PulseEventInfo]:
 		if self.event_callback is not None:
 			raise RuntimeError('Only a single subscribe_events generator can be used at a time.')
-		queue = asyncio.queues.Queue()
+		queue = asyncio.Queue()
 		self.event_callback = queue.put_nowait
 		try:
 			await self._event_mask_set(*masks)

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -423,15 +423,15 @@ class PulseAsync(object):
 		if self.event_callback is not None:
 			raise RuntimeError('Only a single subscribe_events generator can be used at a time.')
 		queue = asyncio.queues.Queue()
-		await self._event_mask_set(*masks)
-
+		self.event_callback = queue.put_nowait
 		try:
+			await self._event_mask_set(*masks)
 			while True:
 				yield await self._wait_disconnect_or(queue.get())
 		finally:
 			self.event_callback = None
 			if self.connected:
-				await self._event_mask_set(0)
+				await self._event_mask_set('null')
 
 	async def get_peak_sample(self, source, timeout, stream_idx=None):
 		'''Returns peak (max) value in 0-1.0 range for samples in source/stream within timespan.

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -97,6 +97,13 @@ class PulseAsync(object):
 	def __enter__(self): return self
 	def __exit__(self, err_t, err, err_tb): self.close()
 
+	async def __aenter__(self):
+		await self.connect()
+		return self
+
+	async def __aexit__(self, err_t, err, err_tb):
+		self.close()
+
 	async def _wait_disconnect_or(self, coroutine: Coroutine):
 		wait_disconnected = asyncio.create_task(self.disconnected.wait())
 		other_task = asyncio.create_task(coroutine)

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -4,11 +4,9 @@
 
 import asyncio
 import inspect
-import sys
 import itertools as it
 import functools as ft
-import traceback
-from contextlib import contextmanager, asynccontextmanager
+from contextlib import asynccontextmanager
 from typing import Optional, AsyncIterator, Coroutine
 
 from .pa_asyncio_mainloop import PythonMainLoop
@@ -20,8 +18,6 @@ from .pulsectl import (
 	assert_pulse_object, PulseDisconnected, unicode)
 from . import _pulsectl as c
 
-
-# TODO alternative for event_callback_set (e.g. async generator)
 
 class PulseAsync(object):
 

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -1,0 +1,486 @@
+import asyncio
+import inspect
+import sys
+import itertools as it
+import functools as ft
+import traceback
+from contextlib import contextmanager, asynccontextmanager
+from typing import Optional
+
+from .pa_asyncio_mainloop import PythonMainLoop
+from .pulsectl import PulseError, PulseEventTypeEnum, PulseEventFacilityEnum, PulseEventInfo, \
+	PulseEventMaskEnum, PulseLoopStop, PulseOperationFailed, PulseIndexError, PulseSinkInfo, PulseSourceInfo, \
+	PulseCardInfo, PulseSinkInputInfo, PulseSourceOutputInfo, PulseClientInfo, PulseServerInfo, PulseModuleInfo, \
+	is_list, PulseOperationInvalid, PulsePortInfo, PulseExtStreamRestoreInfo, PulseUpdateEnum, is_str, \
+	assert_pulse_object, PulseDisconnected, unicode
+from . import _pulsectl as c
+
+
+# TODO alternative for event_callback_set (e.g. async generator)
+
+class PulseAsync(object):
+
+	_ctx = None
+
+	def __init__(self, client_name=None, server=None, loop: Optional[asyncio.AbstractEventLoop] = None):
+		'''Connects to specified pulse server by default.
+			Specifying "connect=False" here prevents that, but be sure to call connect() later.
+			"connect=False" can also be used here to
+				have control over options passed to connect() method.'''
+		self.name = client_name or 'pulsectl'
+		self.server, self.connected, self.connecting_finished = server, None, asyncio.Event(loop=loop)
+		self._ret = self._ctx = self._loop = None
+		self._actions, self._action_ids = dict(),\
+			it.chain.from_iterable(map(range, it.repeat(2**30)))
+		self.init(loop)
+
+	def init(self, loop: Optional[asyncio.AbstractEventLoop]):
+		self._pa_state_cb = c.PA_STATE_CB_T(self._pulse_state_cb)
+		self._pa_subscribe_cb = c.PA_SUBSCRIBE_CB_T(self._pulse_subscribe_cb)
+
+		self._loop = PythonMainLoop(loop or asyncio.get_event_loop())
+		self._loop_running = self._loop_closed = False
+		self._ret = c.pa.return_value()
+
+		self._ctx_init()
+		self.event_types = sorted(PulseEventTypeEnum._values.values())
+		self.event_facilities = sorted(PulseEventFacilityEnum._values.values())
+		self.event_masks = sorted(PulseEventMaskEnum._values.values())
+		self.event_callback = None
+
+	def _ctx_init(self):
+		if self._ctx:
+			self.disconnect()
+			c.pa.context_unref(self._ctx)
+		self._ctx = c.pa.context_new(self._loop.api_pointer, self.name)
+		c.pa.context_set_state_callback(self._ctx, self._pa_state_cb, None)
+		c.pa.context_set_subscribe_callback(self._ctx, self._pa_subscribe_cb, None)
+
+	async def connect(self, autospawn=False, wait=False):
+		'''Connect to pulseaudio server.
+			"autospawn" option will start new pulse daemon, if necessary.
+			Specifying "wait" option will make function block until pulseaudio server appears.'''
+		if self._loop_closed:
+			raise PulseError('Eventloop object was already'
+				' destroyed and cannot be reused from this instance.')
+		if self.connected is not None: self._ctx_init()
+		flags, self.connected = 0, None
+		self.connecting_finished.clear()
+		if not autospawn: flags |= c.PA_CONTEXT_NOAUTOSPAWN
+		if wait: flags |= c.PA_CONTEXT_NOFAIL
+		try: c.pa.context_connect(self._ctx, self.server, flags, None)
+		except c.pa.CallError: self.connected = False
+		await self.connecting_finished.wait()
+		if self.connected is False: raise PulseError('Failed to connect to pulseaudio server')
+
+	def disconnect(self):
+		if not self._ctx or not self.connected: return
+		c.pa.context_disconnect(self._ctx)
+
+	def close(self):
+		if not self._loop: return
+		try:
+			self.disconnect()
+			c.pa.context_unref(self._ctx)
+			self._loop.stop(0)
+		finally: self._ctx = self._loop = None
+
+	def __enter__(self): return self
+	def __exit__(self, err_t, err, err_tb): self.close()
+
+
+	def _pulse_state_cb(self, ctx, userdata):
+		state = c.pa.context_get_state(ctx)
+		if state >= c.PA_CONTEXT_READY:
+			if state == c.PA_CONTEXT_READY:
+				self.connected = True
+				self.connecting_finished.set()
+			elif state in [c.PA_CONTEXT_FAILED, c.PA_CONTEXT_TERMINATED]:
+				self.connected, self._loop_stop = False, True
+				self.connecting_finished.set()
+
+	def _pulse_subscribe_cb(self, ctx, ev, idx, userdata):
+		if not self.event_callback: return
+		n = ev & c.PA_SUBSCRIPTION_EVENT_FACILITY_MASK
+		ev_fac = PulseEventFacilityEnum._c_val(n, 'ev.facility.{}'.format(n))
+		n = ev & c.PA_SUBSCRIPTION_EVENT_TYPE_MASK
+		ev_t = PulseEventTypeEnum._c_val(n, 'ev.type.{}'.format(n))
+		try: self.event_callback(PulseEventInfo(ev_t, ev_fac, idx))
+		except PulseLoopStop: self._loop_stop = True
+
+	def _pulse_poll_cb(self, func, func_err, ufds, nfds, timeout, userdata):
+		fd_list = list(ufds[n] for n in range(nfds))
+		try: nfds = func(fd_list, timeout / 1000.0)
+		except Exception as err:
+			func_err(*sys.exc_info())
+			return -1
+		return nfds
+
+	@asynccontextmanager
+	async def _pulse_op_cb(self, raw=False):
+		act_id = next(self._action_ids)
+		self._actions[act_id] = self._loop.loop.create_future()
+		try:
+			def cb (s=True,k=act_id):
+				print(f"Set future for action {act_id} ({s})")
+				if s: self._loop.loop.call_soon_threadsafe(self._actions[k].set_result, None)
+				else: self._loop.loop.call_soon_threadsafe(self._actions[k].set_exception, PulseOperationFailed(act_id))
+			if not raw: cb = c.PA_CONTEXT_SUCCESS_CB_T(lambda ctx,s,d,cb=cb: cb(s))
+			yield cb
+			await self._actions[act_id]  # await disconnect simultaneously
+		finally: self._actions.pop(act_id, None)
+
+
+	def _pulse_info_cb(self, info_cls, data_list, done_cb, ctx, info, eof, userdata):
+		# No idea where callbacks with "userdata != NULL" come from,
+		#  but "info" pointer in them is always invalid, so they are discarded here.
+		# Looks like some kind of mixup or corruption in libpulse memory?
+		# See also: https://github.com/mk-fg/python-pulse-control/issues/35
+		if userdata is not None: return
+		# Empty result list and conn issues are checked elsewhere.
+		# Errors here are non-descriptive (errno), so should not be useful anyway.
+		# if eof < 0: done_cb(s=False)
+		if eof: done_cb()
+		else: data_list.append(info_cls(info[0]))
+
+	def _pulse_get_list(cb_t, pulse_func, info_cls, singleton=False, index_arg=True):
+		async def _wrapper_method(self, index=None):
+			data = list()
+			async with self._pulse_op_cb(raw=True) as cb:
+				cb = cb_t(
+					ft.partial(self._pulse_info_cb, info_cls, data, cb) if not singleton else
+					lambda ctx, info, userdata, cb=cb: data.append(info_cls(info[0])) or cb() )
+				pa_op = pulse_func( self._ctx,
+					*([index, cb, None] if index is not None else [cb, None]) )
+			c.pa.operation_unref(pa_op)
+			data = data or list()
+			if index is not None or singleton:
+				if not data: raise PulseIndexError(index)
+				data, = data
+			return data
+		_wrapper_method.__name__ = '...'
+		_wrapper_method.__doc__ = 'Signature: func({})'.format(
+			'' if pulse_func.__name__.endswith('_list') or singleton or not index_arg else 'index' )
+		return _wrapper_method
+
+	get_sink_by_name = _pulse_get_list(
+		c.PA_SINK_INFO_CB_T,
+		c.pa.context_get_sink_info_by_name, PulseSinkInfo )
+	get_source_by_name = _pulse_get_list(
+		c.PA_SOURCE_INFO_CB_T,
+		c.pa.context_get_source_info_by_name, PulseSourceInfo )
+	get_card_by_name = _pulse_get_list(
+		c.PA_CARD_INFO_CB_T,
+		c.pa.context_get_card_info_by_name, PulseCardInfo )
+
+	sink_input_list = _pulse_get_list(
+		c.PA_SINK_INPUT_INFO_CB_T,
+		c.pa.context_get_sink_input_info_list, PulseSinkInputInfo )
+	sink_input_info = _pulse_get_list(
+		c.PA_SINK_INPUT_INFO_CB_T,
+		c.pa.context_get_sink_input_info, PulseSinkInputInfo )
+	source_output_list = _pulse_get_list(
+		c.PA_SOURCE_OUTPUT_INFO_CB_T,
+		c.pa.context_get_source_output_info_list, PulseSourceOutputInfo )
+	source_output_info = _pulse_get_list(
+		c.PA_SOURCE_OUTPUT_INFO_CB_T,
+		c.pa.context_get_source_output_info, PulseSourceOutputInfo )
+
+	sink_list = _pulse_get_list(
+		c.PA_SINK_INFO_CB_T, c.pa.context_get_sink_info_list, PulseSinkInfo )
+	sink_info = _pulse_get_list(
+		c.PA_SINK_INFO_CB_T, c.pa.context_get_sink_info_by_index, PulseSinkInfo )
+	source_list = _pulse_get_list(
+		c.PA_SOURCE_INFO_CB_T, c.pa.context_get_source_info_list, PulseSourceInfo )
+	source_info = _pulse_get_list(
+		c.PA_SOURCE_INFO_CB_T, c.pa.context_get_source_info_by_index, PulseSourceInfo )
+	card_list = _pulse_get_list(
+		c.PA_CARD_INFO_CB_T, c.pa.context_get_card_info_list, PulseCardInfo )
+	card_info = _pulse_get_list(
+		c.PA_CARD_INFO_CB_T, c.pa.context_get_card_info_by_index, PulseCardInfo )
+	client_list = _pulse_get_list(
+		c.PA_CLIENT_INFO_CB_T, c.pa.context_get_client_info_list, PulseClientInfo )
+	client_info = _pulse_get_list(
+		c.PA_CLIENT_INFO_CB_T, c.pa.context_get_client_info, PulseClientInfo )
+	server_info = _pulse_get_list(
+		c.PA_SERVER_INFO_CB_T, c.pa.context_get_server_info, PulseServerInfo, singleton=True )
+	module_info = _pulse_get_list(
+		c.PA_MODULE_INFO_CB_T, c.pa.context_get_module_info, PulseModuleInfo )
+	module_list = _pulse_get_list(
+		c.PA_MODULE_INFO_CB_T, c.pa.context_get_module_info_list, PulseModuleInfo )
+
+	def _pulse_method_call(pulse_op, func=None, index_arg=True):
+		'''Creates following synchronous wrapper for async pa_operation callable:
+			wrapper(index, ...) -> pulse_op(index, [*]args_func(...))
+			index_arg=False: wrapper(...) -> pulse_op([*]args_func(...))'''
+		async def _wrapper(self, *args, **kws):
+			if index_arg:
+				if 'index' in kws: index = kws.pop('index')
+				else: index, args = args[0], args[1:]
+			pulse_args = func(*args, **kws) if func else list()
+			if not is_list(pulse_args): pulse_args = [pulse_args]
+			if index_arg: pulse_args = [index] + list(pulse_args)
+			async with self._pulse_op_cb() as cb:
+				try: pulse_op(self._ctx, *(list(pulse_args) + [cb, None]))
+				except c.ArgumentError as err: raise TypeError(err.args)
+				except c.pa.CallError as err: raise PulseOperationInvalid(err.args[-1])
+		func_args = list(inspect.getargspec(func or (lambda: None)))
+		func_args[0] = list(func_args[0])
+		if index_arg: func_args[0] = ['index'] + func_args[0]
+		_wrapper.__name__ = '...'
+		_wrapper.__doc__ = 'Signature: func' + inspect.formatargspec(*func_args)
+		if func.__doc__: _wrapper.__doc__ += '\n\n' + func.__doc__
+		return _wrapper
+
+	card_profile_set_by_index = _pulse_method_call(
+		c.pa.context_set_card_profile_by_index, lambda profile_name: profile_name )
+
+	sink_default_set = _pulse_method_call(
+		c.pa.context_set_default_sink, index_arg=False,
+		func=lambda sink: sink.name if isinstance(sink, PulseSinkInfo) else sink )
+	source_default_set = _pulse_method_call(
+		c.pa.context_set_default_source, index_arg=False,
+		func=lambda source: source.name if isinstance(source, PulseSourceInfo) else source )
+
+	sink_input_mute = _pulse_method_call(
+		c.pa.context_set_sink_input_mute, lambda mute=True: mute )
+	sink_input_move = _pulse_method_call(
+		c.pa.context_move_sink_input_by_index, lambda sink_index: sink_index )
+	sink_mute = _pulse_method_call(
+		c.pa.context_set_sink_mute_by_index, lambda mute=True: mute )
+	sink_input_volume_set = _pulse_method_call(
+		c.pa.context_set_sink_input_volume, lambda vol: vol.to_struct() )
+	sink_volume_set = _pulse_method_call(
+		c.pa.context_set_sink_volume_by_index, lambda vol: vol.to_struct() )
+	sink_suspend = _pulse_method_call(
+		c.pa.context_suspend_sink_by_index, lambda suspend=True: suspend )
+	sink_port_set = _pulse_method_call(
+		c.pa.context_set_sink_port_by_index,
+		lambda port: port.name if isinstance(port, PulsePortInfo) else port )
+
+	source_output_mute = _pulse_method_call(
+		c.pa.context_set_source_output_mute, lambda mute=True: mute )
+	source_output_move = _pulse_method_call(
+		c.pa.context_move_source_output_by_index, lambda sink_index: sink_index )
+	source_mute = _pulse_method_call(
+		c.pa.context_set_source_mute_by_index, lambda mute=True: mute )
+	source_output_volume_set = _pulse_method_call(
+		c.pa.context_set_source_output_volume, lambda vol: vol.to_struct() )
+	source_volume_set = _pulse_method_call(
+		c.pa.context_set_source_volume_by_index, lambda vol: vol.to_struct() )
+	source_suspend = _pulse_method_call(
+		c.pa.context_suspend_source_by_index, lambda suspend=True: suspend )
+	source_port_set = _pulse_method_call(
+		c.pa.context_set_source_port_by_index,
+		lambda port: port.name if isinstance(port, PulsePortInfo) else port )
+
+
+	async def module_load(self, name, args=''):
+		if is_list(args): args = ' '.join(args)
+		name, args = map(c.force_bytes, [name, args])
+		data = list()
+		async with self._pulse_op_cb(raw=True) as cb:
+			cb = c.PA_CONTEXT_INDEX_CB_T(
+				lambda ctx, index, userdata, cb=cb: data.append(index) or cb() )
+			try: c.pa.context_load_module(self._ctx, name, args, cb, None)
+			except c.pa.CallError as err: raise PulseOperationInvalid(err.args[-1])
+		index, = data
+		return index
+
+	module_unload = _pulse_method_call(c.pa.context_unload_module, None)
+
+
+	async def stream_restore_test(self):
+		'Returns module-stream-restore version int (e.g. 1) or None if it is unavailable.'
+		data = list()
+		async with self._pulse_op_cb(raw=True) as cb:
+			cb = c.PA_EXT_STREAM_RESTORE_TEST_CB_T(
+				lambda ctx, version, userdata, cb=cb: data.append(version) or cb() )
+			try: c.pa.ext_stream_restore_test(self._ctx, cb, None)
+			except c.pa.CallError as err: raise PulseOperationInvalid(err.args[-1])
+		version, = data
+		return version if version != c.PA_INVALID else None
+
+	stream_restore_read = _pulse_get_list(
+		c.PA_EXT_STREAM_RESTORE_READ_CB_T,
+		c.pa.ext_stream_restore_read, PulseExtStreamRestoreInfo, index_arg=False )
+	stream_restore_list = stream_restore_read # for consistency with other *_list methods
+
+	@ft.partial(_pulse_method_call, c.pa.ext_stream_restore_write, index_arg=False)
+	def stream_restore_write( obj_name_or_list,
+			mode='merge', apply_immediately=False, **obj_kws ):
+		'''Update module-stream-restore db entry for specified name.
+			Can be passed PulseExtStreamRestoreInfo object or list of them as argument,
+				or name string there and object init keywords (e.g. volume, mute, channel_list, etc).
+			"mode" is PulseUpdateEnum value of
+				'merge' (default), 'replace' or 'set' (replaces ALL entries!!!).'''
+		mode = PulseUpdateEnum[mode]._c_val
+		if is_str(obj_name_or_list):
+			obj_name_or_list = PulseExtStreamRestoreInfo(obj_name_or_list, **obj_kws)
+		if isinstance(obj_name_or_list, PulseExtStreamRestoreInfo):
+			obj_name_or_list = [obj_name_or_list]
+		# obj_array is an array of structs, laid out contiguously in memory, not pointers
+		obj_array = (c.PA_EXT_STREAM_RESTORE_INFO * len(obj_name_or_list))()
+		for n, obj in enumerate(obj_name_or_list):
+			obj_struct, dst_struct = obj.to_struct(), obj_array[n]
+			for k,t in obj_struct._fields_: setattr(dst_struct, k, getattr(obj_struct, k))
+		return mode, obj_array, len(obj_array), int(bool(apply_immediately))
+
+	@ft.partial(_pulse_method_call, c.pa.ext_stream_restore_delete, index_arg=False)
+	def stream_restore_delete(obj_name_or_list):
+		'''Can be passed string name,
+			PulseExtStreamRestoreInfo object or a list of any of these.'''
+		if is_str(obj_name_or_list, PulseExtStreamRestoreInfo):
+			obj_name_or_list = [obj_name_or_list]
+		name_list = list((obj.name if isinstance( obj,
+			PulseExtStreamRestoreInfo ) else obj) for obj in obj_name_or_list)
+		name_struct = (c.c_char_p * len(name_list))()
+		name_struct[:] = list(map(c.force_bytes, name_list))
+		return [name_struct]
+
+
+	def default_set(self, obj):
+		'Set passed sink or source to be used as default one by pulseaudio server.'
+		assert_pulse_object(obj)
+		method = {
+			PulseSinkInfo: self.sink_default_set,
+			PulseSourceInfo: self.source_default_set }.get(type(obj))
+		if not method: raise NotImplementedError(type(obj))
+		method(obj)
+
+	def mute(self, obj, mute=True):
+		assert_pulse_object(obj)
+		method = {
+			PulseSinkInfo: self.sink_mute,
+			PulseSinkInputInfo: self.sink_input_mute,
+			PulseSourceInfo: self.source_mute,
+			PulseSourceOutputInfo: self.source_output_mute }.get(type(obj))
+		if not method: raise NotImplementedError(type(obj))
+		method(obj.index, mute)
+		obj.mute = mute
+
+	def port_set(self, obj, port):
+		assert_pulse_object(obj)
+		method = {
+			PulseSinkInfo: self.sink_port_set,
+			PulseSourceInfo: self.source_port_set }.get(type(obj))
+		if not method: raise NotImplementedError(type(obj))
+		method(obj.index, port)
+		obj.port_active = port
+
+	def card_profile_set(self, card, profile):
+		assert_pulse_object(card)
+		if is_str(profile):
+			profile_dict = dict((p.name, p) for p in card.profile_list)
+			if profile not in profile_dict:
+				raise PulseIndexError( 'Card does not have'
+					' profile with specified name: {!r}'.format(profile) )
+			profile = profile_dict[profile]
+		self.card_profile_set_by_index(card.index, profile.name)
+		card.profile_active = profile
+
+	async def volume_set(self, obj, vol):
+		assert_pulse_object(obj)
+		method = {
+			PulseSinkInfo: self.sink_volume_set,
+			PulseSinkInputInfo: self.sink_input_volume_set,
+			PulseSourceInfo: self.source_volume_set,
+			PulseSourceOutputInfo: self.source_output_volume_set }.get(type(obj))
+		if not method: raise NotImplementedError(type(obj))
+		await method(obj.index, vol)
+		obj.volume = vol
+
+	async def volume_set_all_chans(self, obj, vol):
+		assert_pulse_object(obj)
+		obj.volume.value_flat = vol
+		await self.volume_set(obj, obj.volume)
+
+	async def volume_change_all_chans(self, obj, inc):
+		assert_pulse_object(obj)
+		obj.volume.values = [max(0, v + inc) for v in obj.volume.values]
+		await self.volume_set(obj, obj.volume)
+
+	def volume_get_all_chans(self, obj):
+		# Purpose of this func can be a bit confusing, being here next to set/change ones
+		'''Get "flat" volume float value for info-object as a mean of all channel values.
+			Note that this DOES NOT query any kind of updated values from libpulse,
+				and simply returns value(s) stored in passed object, i.e. same ones for same object.'''
+		assert_pulse_object(obj)
+		return obj.volume.value_flat
+
+
+	def event_mask_set(self, *masks):
+		mask = 0
+		for m in masks: mask |= PulseEventMaskEnum[m]._c_val
+		with self._pulse_op_cb() as cb:
+			c.pa.context_subscribe(self._ctx, mask, cb, None)
+
+
+	def get_peak_sample(self, source, timeout, stream_idx=None):
+		'''Returns peak (max) value in 0-1.0 range for samples in source/stream within timespan.
+			"source" can be either int index of pulseaudio source
+				(i.e. source.index), its name (source.name), or None to use default source.
+			Resulting value is what pulseaudio returns as
+				PA_SAMPLE_FLOAT32BE float after "timeout" seconds.
+			If specified source does not exist, 0 should be returned after timeout.
+			This can be used to detect if there's any sound
+				on the microphone or any sound played through a sink via its monitor_source index,
+				or same for any specific stream connected to these (if "stream_idx" is passed).
+			Sample stream masquerades as
+				application.id=org.PulseAudio.pavucontrol to avoid being listed in various mixer apps.
+			Example - get peak for specific sink input "si" for 0.8 seconds:
+				pulse.get_peak_sample(pulse.sink_info(si.sink).monitor_source, 0.8, si.index)'''
+		samples, proplist = [0], c.pa.proplist_from_string('application.id=org.PulseAudio.pavucontrol')
+		ss = c.PA_SAMPLE_SPEC(format=c.PA_SAMPLE_FLOAT32BE, rate=25, channels=1)
+		s = c.pa.stream_new_with_proplist(self._ctx, 'peak detect', c.byref(ss), None, proplist)
+		c.pa.proplist_free(proplist)
+
+		@c.PA_STREAM_REQUEST_CB_T
+		def read_cb(s, bs, userdata):
+			buff, bs = c.c_void_p(), c.c_int(bs)
+			c.pa.stream_peek(s, buff, c.byref(bs))
+			try:
+				if not buff or bs.value < 4: return
+				# This assumes that native byte order for floats is BE, same as pavucontrol
+				samples[0] = max(samples[0], c.cast(buff, c.POINTER(c.c_float))[0])
+			finally:
+				# stream_drop() flushes buffered data (incl. buff=NULL "hole" data)
+				# stream.h: "should not be called if the buffer is empty"
+				if bs.value: c.pa.stream_drop(s)
+
+		if stream_idx is not None: c.pa.stream_set_monitor_stream(s, stream_idx)
+		c.pa.stream_set_read_callback(s, read_cb, None)
+		if source is not None: source = unicode(source).encode('utf-8')
+		try:
+			c.pa.stream_connect_record( s, source,
+				c.PA_BUFFER_ATTR(fragsize=4, maxlength=2**32-1),
+				c.PA_STREAM_DONT_MOVE | c.PA_STREAM_PEAK_DETECT |
+					c.PA_STREAM_ADJUST_LATENCY | c.PA_STREAM_DONT_INHIBIT_AUTO_SUSPEND )
+		except c.pa.CallError:
+			c.pa.stream_unref(s)
+			raise
+
+		try: self._pulse_poll(timeout)  # FIXME
+		finally:
+			try: c.pa.stream_disconnect(s)
+			except c.pa.CallError: pass # stream was removed
+
+		return min(1.0, samples[0])
+
+	async def play_sample(self, name, sink=None, volume=1.0, proplist_str=None):
+		'''Play specified sound sample,
+				with an optional sink object/name/index, volume and proplist string parameters.
+			Sample must be stored on the server in advance, see e.g. "pacmd list-samples".
+			See also libcanberra for an easy XDG theme sample loading, storage and playback API.'''
+		if isinstance(sink, PulseSinkInfo): sink = sink.index
+		sink = str(sink) if sink is not None else None
+		proplist = c.pa.proplist_from_string(proplist_str) if proplist_str else None
+		volume = int(round(volume*c.PA_VOLUME_NORM))
+		async with self._pulse_op_cb() as cb:
+			try:
+				if not proplist:
+					c.pa.context_play_sample(self._ctx, name, sink, volume, cb, None)
+				else:
+					c.pa.context_play_sample_with_proplist(
+						self._ctx, name, sink, volume, proplist, cb, None )
+			except c.pa.CallError as err: raise PulseOperationInvalid(err.args[-1])

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -1,3 +1,7 @@
+#
+# Copyright (c) 2014 George Filipkin, 2021 Michael Thies
+#
+
 import asyncio
 import inspect
 import sys

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -491,7 +491,11 @@ class PulseAsync(object):
 			c.pa.stream_unref(s)
 			raise
 
-		await asyncio.sleep(timeout)
+		try:
+			await asyncio.wait_for(self.disconnected.wait(), timeout)
+			raise PulseDisconnected()
+		except asyncio.TimeoutError:
+			pass
 
 		try: c.pa.stream_disconnect(s)
 		except c.pa.CallError: pass # stream was removed

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -341,16 +341,16 @@ class PulseAsync(object):
 		return [name_struct]
 
 
-	def default_set(self, obj):
+	async def default_set(self, obj):
 		'Set passed sink or source to be used as default one by pulseaudio server.'
 		assert_pulse_object(obj)
 		method = {
 			PulseSinkInfo: self.sink_default_set,
 			PulseSourceInfo: self.source_default_set }.get(type(obj))
 		if not method: raise NotImplementedError(type(obj))
-		method(obj)
+		await method(obj)
 
-	def mute(self, obj, mute=True):
+	async def mute(self, obj, mute=True):
 		assert_pulse_object(obj)
 		method = {
 			PulseSinkInfo: self.sink_mute,
@@ -358,19 +358,19 @@ class PulseAsync(object):
 			PulseSourceInfo: self.source_mute,
 			PulseSourceOutputInfo: self.source_output_mute }.get(type(obj))
 		if not method: raise NotImplementedError(type(obj))
-		method(obj.index, mute)
+		await method(obj.index, mute)
 		obj.mute = mute
 
-	def port_set(self, obj, port):
+	async def port_set(self, obj, port):
 		assert_pulse_object(obj)
 		method = {
 			PulseSinkInfo: self.sink_port_set,
 			PulseSourceInfo: self.source_port_set }.get(type(obj))
 		if not method: raise NotImplementedError(type(obj))
-		method(obj.index, port)
+		await method(obj.index, port)
 		obj.port_active = port
 
-	def card_profile_set(self, card, profile):
+	async def card_profile_set(self, card, profile):
 		assert_pulse_object(card)
 		if is_str(profile):
 			profile_dict = dict((p.name, p) for p in card.profile_list)
@@ -378,7 +378,7 @@ class PulseAsync(object):
 				raise PulseIndexError( 'Card does not have'
 					' profile with specified name: {!r}'.format(profile) )
 			profile = profile_dict[profile]
-		self.card_profile_set_by_index(card.index, profile.name)
+		await self.card_profile_set_by_index(card.index, profile.name)
 		card.profile_active = profile
 
 	async def volume_set(self, obj, vol):
@@ -402,7 +402,7 @@ class PulseAsync(object):
 		obj.volume.values = [max(0, v + inc) for v in obj.volume.values]
 		await self.volume_set(obj, obj.volume)
 
-	def volume_get_all_chans(self, obj):
+	async def volume_get_all_chans(self, obj):
 		# Purpose of this func can be a bit confusing, being here next to set/change ones
 		'''Get "flat" volume float value for info-object as a mean of all channel values.
 			Note that this DOES NOT query any kind of updated values from libpulse,

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -436,6 +436,13 @@ class PulseAsync(object):
 			c.pa.context_subscribe(self._ctx, mask, cb, None)
 
 	async def subscribe_events(self, *masks) -> AsyncIterator[PulseEventInfo]:
+		'''Subscribes to PulseAudio events with the given event masks and creates an asynchronous
+				iterator, yielding the events as they are received from the server.
+			This method is an alternative to `event_callback_set` and `event_mask_set`.
+
+			Raises a `PulseDisconnect` exception when the connection to the server is lost.
+			Raises StopIteration (returns silently from for loop) when the event subscription is
+				cancelled via `event_callback_set(None)`'''
 		if self.event_callback is not None:
 			raise RuntimeError('Only a single subscribe_events generator can be used at a time.')
 		queue = asyncio.Queue()

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -68,7 +68,7 @@ class PulseAsync(object):
 		'''Connect to pulseaudio server.
 			"autospawn" option will start new pulse daemon, if necessary.
 			Specifying "wait" option will make function block until pulseaudio server appears.'''
-		if self.connected.is_set():
+		if self.connected.is_set() or self.disconnected.is_set():
 			self._ctx_init()
 		flags = 0
 		if not autospawn:
@@ -79,6 +79,7 @@ class PulseAsync(object):
 			c.pa.context_connect(self._ctx, self.server, flags, None)
 			await self._wait_disconnect_or(self.connected.wait())
 		except (c.pa.CallError, PulseDisconnected) as e:
+			self.disconnected.set()
 			raise PulseError('Failed to connect to pulseaudio server') from e
 
 	def disconnect(self):

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -8,11 +8,12 @@ from contextlib import contextmanager, asynccontextmanager
 from typing import Optional
 
 from .pa_asyncio_mainloop import PythonMainLoop
-from .pulsectl import PulseError, PulseEventTypeEnum, PulseEventFacilityEnum, PulseEventInfo, \
-	PulseEventMaskEnum, PulseLoopStop, PulseOperationFailed, PulseIndexError, PulseSinkInfo, PulseSourceInfo, \
-	PulseCardInfo, PulseSinkInputInfo, PulseSourceOutputInfo, PulseClientInfo, PulseServerInfo, PulseModuleInfo, \
-	is_list, PulseOperationInvalid, PulsePortInfo, PulseExtStreamRestoreInfo, PulseUpdateEnum, is_str, \
-	assert_pulse_object, PulseDisconnected, unicode
+from .pulsectl import (
+	PulseError, PulseEventTypeEnum, PulseEventFacilityEnum, PulseEventInfo,
+	PulseEventMaskEnum, PulseLoopStop, PulseOperationFailed, PulseIndexError, PulseSinkInfo, PulseSourceInfo,
+	PulseCardInfo, PulseSinkInputInfo, PulseSourceOutputInfo, PulseClientInfo, PulseServerInfo, PulseModuleInfo,
+	is_list, PulseOperationInvalid, PulsePortInfo, PulseExtStreamRestoreInfo, PulseUpdateEnum, is_str,
+	assert_pulse_object, PulseDisconnected, unicode)
 from . import _pulsectl as c
 
 
@@ -88,8 +89,7 @@ class PulseAsync(object):
 	def __enter__(self): return self
 	def __exit__(self, err_t, err, err_tb): self.close()
 
-
-	def _pulse_state_cb(self, ctx, userdata):
+	def _pulse_state_cb(self, ctx, _userdata):
 		state = c.pa.context_get_state(ctx)
 		if state >= c.PA_CONTEXT_READY:
 			if state == c.PA_CONTEXT_READY:

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -433,7 +433,7 @@ class PulseAsync(object):
 			if self.connected:
 				await self._event_mask_set(0)
 
-	def get_peak_sample(self, source, timeout, stream_idx=None):
+	async def get_peak_sample(self, source, timeout, stream_idx=None):
 		'''Returns peak (max) value in 0-1.0 range for samples in source/stream within timespan.
 			"source" can be either int index of pulseaudio source
 				(i.e. source.index), its name (source.name), or None to use default source.
@@ -477,10 +477,10 @@ class PulseAsync(object):
 			c.pa.stream_unref(s)
 			raise
 
-		try: self._pulse_poll(timeout)  # FIXME
-		finally:
-			try: c.pa.stream_disconnect(s)
-			except c.pa.CallError: pass # stream was removed
+		await asyncio.sleep(timeout)
+
+		try: c.pa.stream_disconnect(s)
+		except c.pa.CallError: pass # stream was removed
 
 		return min(1.0, samples[0])
 

--- a/pulsectl/pulsectl_async.py
+++ b/pulsectl/pulsectl_async.py
@@ -64,14 +64,17 @@ class PulseAsync(object):
 		c.pa.context_set_state_callback(self._ctx, self._pa_state_cb, None)
 		c.pa.context_set_subscribe_callback(self._ctx, self._pa_subscribe_cb, None)
 
-	async def connect(self, autospawn=False):
+	async def connect(self, autospawn=False, wait=False):
 		'''Connect to pulseaudio server.
-			"autospawn" option will start new pulse daemon, if necessary.'''
+			"autospawn" option will start new pulse daemon, if necessary.
+			Specifying "wait" option will make function block until pulseaudio server appears.'''
 		if self.connected.is_set():
 			self._ctx_init()
 		flags = 0
 		if not autospawn:
 			flags |= c.PA_CONTEXT_NOAUTOSPAWN
+		if wait:
+			flags |= c.PA_CONTEXT_NOFAIL
 		try:
 			c.pa.context_connect(self._ctx, self.server, flags, None)
 			await self._wait_disconnect_or(self.connected.wait())

--- a/pulsectl/tests/all.py
+++ b/pulsectl/tests/all.py
@@ -2,3 +2,4 @@
 from __future__ import absolute_import
 
 from .dummy_instance import DummyTests, PulseCrashTests
+from .dummy_instance_async import AsyncDummyTests, PulseCrashTestsAsync

--- a/pulsectl/tests/dummy_instance_async.py
+++ b/pulsectl/tests/dummy_instance_async.py
@@ -1,0 +1,474 @@
+import asyncio
+import atexit
+import functools
+import os
+import signal
+import subprocess
+import sys
+import unittest
+
+import pulsectl
+from pulsectl.pulsectl import unicode
+from pulsectl.tests.dummy_instance import dummy_pulse_init, dummy_pulse_cleanup
+
+
+def async_test(f):
+    """
+    Decorator to transform async unittest coroutines into normal test methods
+    """
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(f(*args, **kwargs))
+    return wrapper
+
+
+@unittest.skipUnless(sys.version_info >= (3, 6), "Python 3.6 or higher required for asynchronous interface.")
+class AsyncDummyTests(unittest.TestCase):
+
+	proc = tmp_dir = None
+
+	@classmethod
+	def setUpClass(cls):
+		assert not cls.proc and not cls.tmp_dir, [cls.proc, cls.tmp_dir]
+
+		for sig in 'hup', 'term', 'int':
+			signal.signal(getattr(signal, 'sig{}'.format(sig).upper()), lambda sig,frm: sys.exit())
+		atexit.register(cls.tearDownClass)
+
+		cls.instance_info = dummy_pulse_init()
+		for k, v in cls.instance_info.items(): setattr(cls, k, v)
+
+	@classmethod
+	def tearDownClass(cls):
+		dummy_pulse_cleanup(cls.instance_info)
+		cls.proc = cls.tmp_dir = None
+
+
+	# Fuzzy float comparison is necessary for volume,
+	#  as these loose precision when converted to/from pulse int values.
+
+	_compare_floats_rounding = 3
+	def _compare_floats(self, a, b, msg=None):
+		if round(a, self._compare_floats_rounding) != round(b, self._compare_floats_rounding):
+			return self._baseAssertEqual(a, b, msg)
+
+	def __init__(self, *args, **kws):
+		super(AsyncDummyTests, self).__init__(*args, **kws)
+		self.addTypeEqualityFunc(float, self._compare_floats)
+
+
+	@async_test
+	async def test_connect(self):
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			si = await pulse.server_info()
+		with pulsectl.PulseAsync('t', server=self.sock_tcp4) as pulse:
+			await pulse.connect()
+			si4 = await pulse.server_info()
+		self.assertEqual(vars(si), vars(si4))
+		with pulsectl.PulseAsync('t', server=self.sock_tcp6) as pulse:
+			await pulse.connect()
+			si6 = await pulse.server_info()
+		self.assertEqual(vars(si), vars(si6))
+
+	@async_test
+	async def test_server_info(self):
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			si, srcs, sinks = await pulse.server_info(), await pulse.source_list(), await pulse.sink_list()
+		self.assertEqual(len(srcs), 2)
+		self.assertEqual(len(sinks), 2)
+
+	@async_test
+	async def test_default_set(self):
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			(src1, src2), (sink1, sink2) = (await pulse.source_list())[:2], (await pulse.sink_list())[:2]
+			self.assertNotEqual(sink1.name, sink2.name)
+			self.assertNotEqual(src1.name, src2.name)
+
+			await pulse.default_set(sink1)
+			await pulse.default_set(sink1)
+			await pulse.default_set(src1)
+			si = await pulse.server_info()
+			self.assertEqual(si.default_sink_name, sink1.name)
+			self.assertEqual(si.default_source_name, src1.name)
+
+			await pulse.default_set(sink2)
+			si = await pulse.server_info()
+			self.assertEqual(si.default_sink_name, sink2.name)
+			self.assertEqual(si.default_source_name, src1.name)
+
+			await pulse.default_set(src2)
+			await pulse.default_set(src2)
+			await pulse.default_set(sink1)
+			si = await pulse.server_info()
+			self.assertEqual(si.default_sink_name, sink1.name)
+			self.assertEqual(si.default_source_name, src2.name)
+
+			await pulse.sink_default_set(sink2.name)
+			await pulse.source_default_set(src1.name)
+			si = await pulse.server_info()
+			self.assertEqual(si.default_sink_name, sink2.name)
+			self.assertEqual(si.default_source_name, src1.name)
+
+			nx = 'xxx'
+			self.assertNotIn(nx, [sink1.name, sink2.name])
+			self.assertNotIn(nx, [src1.name, src2.name])
+			with self.assertRaises(TypeError): await pulse.sink_default_set(sink2.index)
+			with self.assertRaises(pulsectl.PulseOperationFailed): await pulse.sink_default_set(nx)
+			with self.assertRaises(pulsectl.PulseOperationFailed): await pulse.source_default_set(nx)
+			si = await pulse.server_info()
+			self.assertEqual(si.default_sink_name, sink2.name)
+			self.assertEqual(si.default_source_name, src1.name)
+
+	@async_test
+	async def test_events(self):
+		with pulsectl.PulseAsync ('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			sink, cb_called = (await pulse.sink_list())[0], list()
+
+			async def listen_events():
+				async for ev in pulse.subscribe_events('all'):
+					self.assertEqual(ev.facility, 'sink')
+					self.assertEqual(ev.t, 'change')
+					self.assertEqual(ev.index, sink.index)
+					cb_called.append(True)
+					break
+			task = asyncio.create_task(listen_events())
+			await asyncio.sleep(0)
+
+			await pulse.volume_set_all_chans(sink, 0.6)
+			await asyncio.sleep(0.05)
+			self.assertTrue(bool(cb_called))
+			self.assertIsNone(pulse.event_callback)
+
+	@async_test
+	async def test_sink_src(self):
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			src, sink = (await pulse.source_list())[0], (await pulse.sink_list())[0]
+			self.assertTrue(src.proplist.get('device.class'))
+			self.assertTrue(isinstance(src.proplist.get('device.class'), unicode))
+			self.assertTrue(isinstance(list(src.proplist.keys())[0], unicode))
+			self.assertTrue(sink.proplist.get('device.class'))
+			self.assertTrue(isinstance(sink.proplist.get('device.class'), unicode))
+			self.assertTrue(isinstance(list(sink.proplist.keys())[0], unicode))
+
+			await pulse.mute(src, False)
+			print(repr(src))
+			self.assertFalse(src.mute)
+			self.assertFalse((await pulse.source_info(src.index)).mute)
+			await pulse.mute(src, True)
+			await pulse.mute(src, True)
+			self.assertTrue(src.mute)
+			self.assertTrue((await pulse.source_info(src.index)).mute)
+			await pulse.mute(src, False)
+
+			await pulse.mute(sink, False)
+			self.assertFalse(sink.mute)
+			self.assertFalse((await pulse.sink_info(sink.index)).mute)
+			await pulse.mute(sink)
+			self.assertTrue(sink.mute)
+			self.assertTrue((await pulse.sink_info(sink.index)).mute)
+			await pulse.mute(sink, False)
+
+			await pulse.volume_set_all_chans(sink, 1.0)
+			self.assertEqual(sink.volume.value_flat, 1.0)
+			self.assertEqual((await pulse.sink_info(sink.index)).volume.values, sink.volume.values)
+			await pulse.volume_set_all_chans(sink, 0.5)
+			self.assertEqual(sink.volume.value_flat, 0.5)
+			self.assertEqual((await pulse.sink_info(sink.index)).volume.values, sink.volume.values)
+			await pulse.volume_change_all_chans(sink, -0.5)
+			self.assertEqual(sink.volume.value_flat, 0.0)
+			self.assertEqual((await pulse.sink_info(sink.index)).volume.values, sink.volume.values)
+			await pulse.volume_set_all_chans(sink, 1.0)
+
+	@async_test
+	async def test_get_sink_src(self):
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			src, sink = await pulse.source_list(), await pulse.sink_list()
+			src_nx, sink_nx = max(s.index for s in src)+1, max(s.index for s in sink)+1
+			src, sink = src[0], sink[0]
+			self.assertEqual(sink.index, (await pulse.get_sink_by_name(sink.name)).index)
+			self.assertEqual(src.index, (await pulse.get_source_by_name(src.name)).index)
+			with self.assertRaises(pulsectl.PulseIndexError): await pulse.source_info(src_nx)
+			with self.assertRaises(pulsectl.PulseIndexError): await pulse.sink_info(sink_nx)
+
+	# def test_get_card(self): no cards to test these calls with :(
+
+	@async_test
+	async def test_module_funcs(self):
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			self.assertEqual(len(await pulse.sink_list()), 2)
+			idx = await pulse.module_load('module-null-sink')
+			self.assertEqual(len(await pulse.sink_list()), 3)
+			await pulse.module_unload(idx)
+			self.assertEqual(len(await pulse.sink_list()), 2)
+
+	@async_test
+	async def test_stream(self):
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			stream_started = asyncio.Event()
+			stream_idx = []
+
+			async def listen_stream_events():
+				async for ev in pulse.subscribe_events('sink_input'):
+					if ev.t == 'new':
+						stream_idx.append(ev.index)
+						stream_started.set()
+						break
+
+			asyncio.create_task(listen_stream_events())
+
+			paplay = subprocess.Popen(
+				['paplay', '--raw', '/dev/zero'], env=dict(
+					PATH=os.environ['PATH'], XDG_RUNTIME_DIR=self.tmp_dir ) )
+			try:
+				await stream_started.wait()
+				self.assertTrue(bool(stream_idx))
+				stream_idx = stream_idx[0]
+
+				stream = await pulse.sink_input_info(stream_idx)
+				self.assertTrue(stream.proplist.get('application.name'))
+				self.assertTrue(isinstance(stream.proplist.get('application.name'), unicode))
+				self.assertTrue(isinstance(list(stream.proplist.keys())[0], unicode))
+
+				await pulse.mute(stream, False)
+				self.assertFalse(stream.mute)
+				self.assertFalse((await pulse.sink_input_info(stream.index)).mute)
+				await pulse.mute(stream)
+				self.assertTrue(stream.mute)
+				self.assertTrue((await pulse.sink_input_info(stream.index)).mute)
+				await pulse.mute(stream, False)
+
+				await pulse.volume_set_all_chans(stream, 1.0)
+				self.assertEqual(stream.volume.value_flat, 1.0)
+				self.assertEqual((await pulse.sink_input_info(stream.index)).volume.values, stream.volume.values)
+				await pulse.volume_set_all_chans(stream, 0.5)
+				self.assertEqual(stream.volume.value_flat, 0.5)
+				self.assertEqual((await pulse.sink_input_info(stream.index)).volume.values, stream.volume.values)
+				await pulse.volume_change_all_chans(stream, -0.5)
+				self.assertEqual(stream.volume.value_flat, 0.0)
+				self.assertEqual((await pulse.sink_input_info(stream.index)).volume.values, stream.volume.values)
+
+			finally:
+				if paplay.poll() is None: paplay.kill()
+				paplay.wait()
+
+			with self.assertRaises(pulsectl.PulseIndexError):
+				await pulse.sink_input_info(stream.index)
+
+	@async_test
+	async def test_ext_stream_restore(self):
+		sr_name1 = 'sink-input-by-application-name:pulsectl-test-1'
+		sr_name2 = 'sink-input-by-application-name:pulsectl-test-2'
+
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			self.assertIsNotNone(await pulse.stream_restore_test())
+
+			await pulse.stream_restore_write(sr_name1, volume=0.5, mute=True)
+			await pulse.stream_restore_write(
+				pulsectl.PulseExtStreamRestoreInfo(sr_name2, volume=0.3, channel_list='mono'),
+				apply_immediately=True )
+
+			sr_list = await pulse.stream_restore_list()
+			self.assertIsInstance(sr_list, list)
+			self.assertTrue(sr_list)
+			sr_dict = dict((sr.name, sr) for sr in sr_list)
+			self.assertEqual(sr_dict[sr_name1].volume.value_flat, 0.5)
+			self.assertEqual(sr_dict[sr_name1].mute, 1)
+			self.assertEqual(sr_dict[sr_name1].channel_list, ['mono'])
+			self.assertIn(sr_name2, sr_dict)
+			self.assertEqual(sr_dict[sr_name2].channel_list, ['mono'])
+
+			await pulse.stream_restore_delete(sr_name1)
+			sr_dict = dict((sr.name, sr) for sr in await pulse.stream_restore_list())
+			self.assertNotIn(sr_name1, sr_dict)
+			self.assertIn(sr_name2, sr_dict)
+
+			await pulse.stream_restore_write(
+				[ pulsectl.PulseExtStreamRestoreInfo( sr_name1,
+						volume=0.7, channel_list=['front-left', 'front-right'] ),
+					sr_dict[sr_name2] ],
+				mode='merge' )
+			await pulse.stream_restore_write(sr_name1,
+				volume=0.3, channel_list='mono', mute=True )
+			sr_dict = dict((sr.name, sr) for sr in await pulse.stream_restore_list())
+			self.assertEqual(sr_dict[sr_name1].volume.value_flat, 0.7)
+			self.assertEqual(sr_dict[sr_name1].mute, 0)
+			self.assertEqual(sr_dict[sr_name1].channel_list, ['front-left', 'front-right'])
+
+			await pulse.stream_restore_write(sr_name1, volume=0.4, mode='replace')
+			sr_dict = dict((sr.name, sr) for sr in await pulse.stream_restore_list())
+			self.assertEqual(sr_dict[sr_name1].volume.value_flat, 0.4)
+
+			await pulse.stream_restore_write(sr_name2, volume=0.9, mode='set')
+			sr_dict = dict((sr.name, sr) for sr in await pulse.stream_restore_list())
+			self.assertEqual(sr_dict[sr_name2].volume.value_flat, 0.9)
+			self.assertEqual(list(sr_dict.keys()), [sr_name2])
+
+			await pulse.stream_restore_write([], mode='set') # i.e. remove all
+			sr_dict = dict((sr.name, sr) for sr in await pulse.stream_restore_list())
+			self.assertNotIn(sr_name1, sr_dict)
+			self.assertNotIn(sr_name2, sr_dict)
+
+	@async_test
+	async def test_stream_move(self):
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			stream_started = asyncio.Event()
+			stream_idx = []
+
+			async def listen_stream_events():
+				async for ev in pulse.subscribe_events('sink_input'):
+					if ev.t == 'new':
+						stream_idx.append(ev.index)
+						stream_started.set()
+						break
+
+			asyncio.create_task(listen_stream_events())
+
+			paplay = subprocess.Popen(
+				['paplay', '--raw', '/dev/zero'], env=dict(
+					PATH=os.environ['PATH'], XDG_RUNTIME_DIR=self.tmp_dir ) )
+			try:
+				await stream_started.wait()
+				self.assertTrue(bool(stream_idx))
+				stream_idx = stream_idx[0]
+
+				stream = await pulse.sink_input_info(stream_idx)
+				sink_indexes = set(s.index for s in await pulse.sink_list())
+				sink1 = stream.sink
+				sink2 = sink_indexes.difference([sink1]).pop()
+				sink_nx = max(sink_indexes) + 1
+
+				await pulse.sink_input_move(stream.index, sink2)
+				stream_new = await pulse.sink_input_info(stream.index)
+				self.assertEqual(stream.sink, sink1) # old info doesn't get updated
+				self.assertEqual(stream_new.sink, sink2)
+
+				await pulse.sink_input_move(stream.index, sink1) # move it back
+				stream_new = await pulse.sink_input_info(stream.index)
+				self.assertEqual(stream_new.sink, sink1)
+
+				with self.assertRaises(pulsectl.PulseOperationFailed):
+					await pulse.sink_input_move(stream.index, sink_nx)
+
+			finally:
+				if paplay.poll() is None: paplay.kill()
+				paplay.wait()
+
+	@async_test
+	async def test_get_peak_sample(self):
+		# Note: this test takes at least multiple seconds to run
+		with pulsectl.PulseAsync('t', server=self.sock_unix) as pulse:
+			await pulse.connect()
+			source_any = max(s.index for s in await pulse.source_list())
+			source_nx = source_any + 1
+
+			await asyncio.sleep(0.3) # make sure previous streams die
+			peak = await pulse.get_peak_sample(source_any, 0.3)
+			self.assertEqual(peak, 0)
+
+			stream_started = asyncio.Event()
+			stream_idx = []
+
+			async def listen_stream_events():
+				async for ev in pulse.subscribe_events('sink_input'):
+					if ev.t == 'new':
+						stream_idx.append(ev.index)
+						stream_started.set()
+						break
+
+			asyncio.create_task(listen_stream_events())
+
+			paplay = subprocess.Popen(
+				['paplay', '--raw', '/dev/zero'], env=dict(
+					PATH=os.environ['PATH'], XDG_RUNTIME_DIR=self.tmp_dir))
+			try:
+				await stream_started.wait()
+				self.assertTrue(bool(stream_idx))
+				stream_idx = stream_idx[0]
+				si = await pulse.sink_input_info(stream_idx)
+				sink = await pulse.sink_info(si.sink)
+				source = await pulse.source_info(sink.monitor_source)
+
+				# First poll can randomly fail if too short, probably due to latency or such
+				peak = await pulse.get_peak_sample(sink.monitor_source, 3)
+				self.assertGreater(peak, 0)
+
+				peak = await pulse.get_peak_sample(source.index, 0.3, si.index)
+				self.assertGreater(peak, 0)
+				peak = await pulse.get_peak_sample(source.name, 0.3, si.index)
+				self.assertGreater(peak, 0)
+				peak = await pulse.get_peak_sample(source_nx, 0.3)
+				self.assertEqual(peak, 0)
+
+				paplay.terminate()
+				paplay.wait()
+
+				peak = await pulse.get_peak_sample(source.index, 0.3, si.index)
+				self.assertEqual(peak, 0)
+
+			finally:
+				if paplay.poll() is None: paplay.kill()
+				paplay.wait()
+
+
+@unittest.skipUnless(sys.version_info >= (3, 6), "Python 3.6 or higher required for asynchronous interface.")
+class PulseCrashTestsAsync(unittest.TestCase):
+
+	@classmethod
+	def setUpClass(cls):
+		for sig in 'hup', 'term', 'int':
+			signal.signal(getattr(signal, 'sig{}'.format(sig).upper()), lambda sig,frm: sys.exit())
+
+	def test_crash_after_connect(self):
+		info = dummy_pulse_init()
+		try:
+			with pulsectl.Pulse('t', server=info.sock_unix) as pulse:
+				for si in pulse.sink_list(): self.assertTrue(si)
+				info.proc.terminate()
+				info.proc.wait()
+				with self.assertRaises(pulsectl.PulseOperationFailed):
+					for si in pulse.sink_list(): raise AssertionError(si)
+				self.assertFalse(pulse.connected)
+		finally: dummy_pulse_cleanup(info)
+
+	@async_test
+	async def test_reconnect(self):
+		info = dummy_pulse_init()
+		try:
+			with pulsectl.PulseAsync('t', server=info.sock_unix) as pulse:
+				with self.assertRaises(Exception):
+					for si in await pulse.sink_list(): raise AssertionError(si)
+
+				await pulse.connect(autospawn=False)
+				self.assertTrue(pulse.connected.is_set())
+				for si in await pulse.sink_list(): self.assertTrue(si)
+				info.proc.terminate()
+				info.proc.wait()
+				with self.assertRaises(Exception):
+					for si in await pulse.sink_list(): raise AssertionError(si)
+				self.assertFalse(pulse.connected.is_set())
+
+				dummy_pulse_init(info)
+				await pulse.connect(autospawn=False, wait=True)
+				self.assertTrue(pulse.connected.is_set())
+				for si in await pulse.sink_list(): self.assertTrue(si)
+
+				pulse.disconnect()
+				with self.assertRaises(Exception):
+					for si in await pulse.sink_list(): raise AssertionError(si)
+				self.assertFalse(pulse.connected.is_set())
+				await pulse.connect(autospawn=False)
+				self.assertTrue(pulse.connected.is_set())
+				for si in await pulse.sink_list(): self.assertTrue(si)
+
+		finally: dummy_pulse_cleanup(info)

--- a/pulsectl/tests/dummy_instance_async.py
+++ b/pulsectl/tests/dummy_instance_async.py
@@ -136,7 +136,8 @@ class AsyncDummyTests(unittest.TestCase):
 					self.assertEqual(ev.index, sink.index)
 					cb_called.append(True)
 					break
-			task = asyncio.create_task(listen_events())
+			loop = asyncio.get_event_loop()
+			loop.create_task(listen_events())
 			await asyncio.sleep(0)
 
 			await pulse.volume_set_all_chans(sink, 0.6)
@@ -223,7 +224,8 @@ class AsyncDummyTests(unittest.TestCase):
 						stream_started.set()
 						break
 
-			asyncio.create_task(listen_stream_events())
+			loop = asyncio.get_event_loop()
+			loop.create_task(listen_stream_events())
 
 			paplay = await asyncio.create_subprocess_exec(
 				'paplay', '--raw', '/dev/zero', env=dict(
@@ -333,7 +335,8 @@ class AsyncDummyTests(unittest.TestCase):
 						stream_started.set()
 						break
 
-			asyncio.create_task(listen_stream_events())
+			loop = asyncio.get_event_loop()
+			loop.create_task(listen_stream_events())
 
 			paplay = await asyncio.create_subprocess_exec(
 				'paplay', '--raw', '/dev/zero', env=dict(
@@ -388,7 +391,8 @@ class AsyncDummyTests(unittest.TestCase):
 						stream_started.set()
 						break
 
-			asyncio.create_task(listen_stream_events())
+			loop = asyncio.get_event_loop()
+			loop.create_task(listen_stream_events())
 
 			paplay = await asyncio.create_subprocess_exec(
 				'paplay', '--raw', '/dev/urandom', env=dict(

--- a/pulsectl/tests/dummy_instance_async.py
+++ b/pulsectl/tests/dummy_instance_async.py
@@ -443,7 +443,7 @@ class PulseCrashTestsAsync(unittest.TestCase):
 				await loop.run_in_executor(None, info.proc.wait)
 				with self.assertRaises(pulsectl.PulseOperationFailed):
 					for si in await pulse.sink_list(): raise AssertionError(si)
-				self.assertFalse(pulse.connected.is_set())
+				self.assertFalse(pulse.connected)
 		finally: await loop.run_in_executor(None, dummy_pulse_cleanup, info)
 
 	@async_test
@@ -456,25 +456,25 @@ class PulseCrashTestsAsync(unittest.TestCase):
 					for si in await pulse.sink_list(): raise AssertionError(si)
 
 				await pulse.connect(autospawn=False)
-				self.assertTrue(pulse.connected.is_set())
+				self.assertTrue(pulse.connected)
 				for si in await pulse.sink_list(): self.assertTrue(si)
 				await loop.run_in_executor(None, info.proc.terminate)
 				await loop.run_in_executor(None, info.proc.wait)
 				with self.assertRaises(Exception):
 					for si in await pulse.sink_list(): raise AssertionError(si)
-				self.assertFalse(pulse.connected.is_set())
+				self.assertFalse(pulse.connected)
 
 				await loop.run_in_executor(None, dummy_pulse_init, info)
 				await pulse.connect(autospawn=False, wait=True)
-				self.assertTrue(pulse.connected.is_set())
+				self.assertTrue(pulse.connected)
 				for si in await pulse.sink_list(): self.assertTrue(si)
 
 				pulse.disconnect()
 				with self.assertRaises(Exception):
 					for si in await pulse.sink_list(): raise AssertionError(si)
-				self.assertFalse(pulse.connected.is_set())
+				self.assertFalse(pulse.connected)
 				await pulse.connect(autospawn=False)
-				self.assertTrue(pulse.connected.is_set())
+				self.assertTrue(pulse.connected)
 				for si in await pulse.sink_list(): self.assertTrue(si)
 
 		finally: await loop.run_in_executor(None, dummy_pulse_cleanup, info)

--- a/pulsectl/tests/dummy_instance_async.py
+++ b/pulsectl/tests/dummy_instance_async.py
@@ -225,9 +225,9 @@ class AsyncDummyTests(unittest.TestCase):
 
 			asyncio.create_task(listen_stream_events())
 
-			paplay = subprocess.Popen(
-				['paplay', '--raw', '/dev/zero'], env=dict(
-					PATH=os.environ['PATH'], XDG_RUNTIME_DIR=self.tmp_dir ) )
+			paplay = await asyncio.create_subprocess_exec(
+				'paplay', '--raw', '/dev/zero', env=dict(
+					PATH=os.environ['PATH'], XDG_RUNTIME_DIR=self.tmp_dir))
 			try:
 				await stream_started.wait()
 				self.assertTrue(bool(stream_idx))
@@ -257,8 +257,9 @@ class AsyncDummyTests(unittest.TestCase):
 				self.assertEqual((await pulse.sink_input_info(stream.index)).volume.values, stream.volume.values)
 
 			finally:
-				if paplay.poll() is None: paplay.kill()
-				paplay.wait()
+				if paplay.returncode is None:
+					paplay.kill()
+				await paplay.wait()
 
 			with self.assertRaises(pulsectl.PulseIndexError):
 				await pulse.sink_input_info(stream.index)
@@ -334,9 +335,9 @@ class AsyncDummyTests(unittest.TestCase):
 
 			asyncio.create_task(listen_stream_events())
 
-			paplay = subprocess.Popen(
-				['paplay', '--raw', '/dev/zero'], env=dict(
-					PATH=os.environ['PATH'], XDG_RUNTIME_DIR=self.tmp_dir ) )
+			paplay = await asyncio.create_subprocess_exec(
+				'paplay', '--raw', '/dev/zero', env=dict(
+					PATH=os.environ['PATH'], XDG_RUNTIME_DIR=self.tmp_dir))
 			try:
 				await stream_started.wait()
 				self.assertTrue(bool(stream_idx))
@@ -361,8 +362,9 @@ class AsyncDummyTests(unittest.TestCase):
 					await pulse.sink_input_move(stream.index, sink_nx)
 
 			finally:
-				if paplay.poll() is None: paplay.kill()
-				paplay.wait()
+				if paplay.returncode is None:
+					paplay.kill()
+				await paplay.wait()
 
 	@async_test
 	async def test_get_peak_sample(self):
@@ -388,8 +390,8 @@ class AsyncDummyTests(unittest.TestCase):
 
 			asyncio.create_task(listen_stream_events())
 
-			paplay = subprocess.Popen(
-				['paplay', '--raw', '/dev/zero'], env=dict(
+			paplay = await asyncio.create_subprocess_exec(
+				'paplay', '--raw', '/dev/urandom', env=dict(
 					PATH=os.environ['PATH'], XDG_RUNTIME_DIR=self.tmp_dir))
 			try:
 				await stream_started.wait()
@@ -411,14 +413,15 @@ class AsyncDummyTests(unittest.TestCase):
 				self.assertEqual(peak, 0)
 
 				paplay.terminate()
-				paplay.wait()
+				await paplay.wait()
 
 				peak = await pulse.get_peak_sample(source.index, 0.3, si.index)
 				self.assertEqual(peak, 0)
 
 			finally:
-				if paplay.poll() is None: paplay.kill()
-				paplay.wait()
+				if paplay.returncode is None:
+					paplay.kill()
+				await paplay.wait()
 
 
 @unittest.skipUnless(sys.version_info >= (3, 6), "Python 3.6 or higher required for asynchronous interface.")


### PR DESCRIPTION
This Pull Request adds a complete asynchronous interface for Python 3's *asyncio* event loop framework to the library. The `PulseAsync` interface class is a 1:1 copy of the current `Pulse` class, except that every method is defined `async`, i.e. returns an awaitable coroutine instead of the plain result. Additionally, I replaced `event_callback_set()` etc. with a method `subscribe_events()` which returns an asynchronous generator over the subscribed events.

For the control flow, I chose none of your options from https://github.com/mk-fg/python-pulse-control/issues/11#issuecomment-259560564, but instead I created a new PulseAudio main_loop_api implementation, using the asyncio event loop to call the registered PA defer/io/timeout event callbacks asynchronously. This requires quite involved ctypes function pointer handling, but it *just works* from a user's perspective: The Pulse Audio asynchronous event handling is completely integrated into the Python asyncio event loop, so we can use pulsectl like any other asyncio library, without needing multiple threads or control flow inversion to get other asynchronous tasks running concurrently with libpulse. This implementation of the libpulse `main_loop_api` is provided in `pa_asyncio_mainloop.py` and is completely independent from the rest of the library – it is only used by the `PulseAsync` class for providing this mainloop implementation to the PulseAudio context.

The `PulseAsync` class shares most of its code with the `Pulse` class, especially all the method/action definitions and the returned `PulseObject` classes with all their magic argument handling. I only needed to rework the state change handling in `_pulse_state_cb()`, `connect()`, etc. and the heart of all PulseAudio methods, the `_pulse_op_cb()` context manager, which waits for the PulseAudio actions to provide a result via a callback method (which is now implemented via asyncio Futures). Apart from that, I only added the `async` keyword here and there.

All the asyncio features *should* be compatible with Python 3.6 and newer, ~~I didn't test on Python 3.6 yet, but I plan to do so.~~ (**EDIT**: tested with Python 3.6. Works.) To avoid breaking the library for older Python versions, the async interface is only included in the `__init__.py` module if `sys.version_info >= (3, 6)`.

I copied the unittest suite in `dummy_instance.py` as well, with similar adaptions (some `async` and `await` here and there`) for using the async interface correctly. On my machine (Python 3.9, PulseAudio 14.2) the tests are all green. (**EDIT**: Same holds on Debian Buster with Python 3.6 and PulseAudio 12.2.)

Due to this simple adaption of the pulsectl module, I decided to try to go the way of adding this async interface (with only minimal changes compared to the existing blocking interface) to this library, instead of writing a new async PulseAudio library from scratch, as you proposed in https://github.com/mk-fg/python-pulse-control/issues/32#issuecomment-523782757. In any case, I would have had to use or rewrite the ctypes wrappers for libpulse (as given in `_pulsectl.py`) in a very similar way and provide some abstraction of the resulting PulseAudio objects like `PulseObject`. Thus, I think it is more appropriate to include the async interface in the pulsectl.
If you don't agree on this, I'll probably publish the code in a new library *on top of* pulsectl.

Fixes #32