### PR TITLE
Remove unnecessary runtime dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,5 @@ setup(
 		'Topic :: Multimedia',
 		'Topic :: Multimedia :: Sound/Audio' ],
 
-	install_requires = ['setuptools'],
-
 	packages = find_packages(),
 	include_package_data = True )


### PR DESCRIPTION
Hi,
I don't see anything that requires this to be present (no references to `setuptools` or `pkg_resouces` in the installed files).