### PR TITLE
tests: pass $HOME to pulseaudio to avoid weird cookie paths

### DIFF
--- a/pulsectl/tests/test_with_dummy_instance.py
+++ b/pulsectl/tests/test_with_dummy_instance.py
@@ -137,7 +137,8 @@ def _dummy_pulse_init(info):
 	if info.proc and info.proc.poll() is not None: info.proc = None
 	if not env_reuse and not info.get('proc'):
 		env = dict( PATH=os.environ['PATH'],
-			XDG_RUNTIME_DIR=tmp_base, PULSE_STATE_PATH=tmp_base )
+			XDG_RUNTIME_DIR=tmp_base, PULSE_STATE_PATH=tmp_base,
+			HOME=os.environ['HOME'] )
 		log_level = 'error' if not env_debug else 'debug'
 		info.proc = subprocess.Popen(
 			['pulseaudio', '--daemonize=no', '--fail',


### PR DESCRIPTION
Hi again,
Without this, pulseaudio tries to start with a cookie in the home directory defined in `passwd`, preventing it to start in some cases.


One example of this is the Gentoo portage sandbox. When `$HOME` is unset, it attempts to create a cookie in a path where it has no write access:
```
W: [pulseaudio] authkey.c: Failed to open cookie file '/var/lib/portage/home/.config/pulse/cookie': No such file or directory                                                                                     
```

The sandbox explicitly sets `$HOME` so that the code running inside it can place its files there. It would be nice if you could keep this environment variable. If not, we will have to keep that patch with the Gentoo package.