### PR TITLE
README: suggest using package managers when possible, link to repology

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -354,7 +354,10 @@ Be sure to use python3/python2, pip3/pip2, easy_install-... binaries below,
 based on which python version you want to install the module for, if you have
 several on the system (as is norm these days for py2-py3 transition).
 
-Using pip_ is the best way::
+`If a package is available for your distribution <https://repology.org/project/python:pulsectl/versions>`_,
+using your package manager is the recommended way to install it.
+
+Otherwise, using pip_ is the best way::
 
   % pip install pulsectl
 


### PR DESCRIPTION
I think that since packages are available for popular distributions like Fedora, openSUSE, Manjaro ([and Gentoo :stuck_out_tongue_closed_eyes:](https://github.com/gentoo/gentoo/commit/3cf5ae45798a0ef42517f12653a3020ed9b7c2ae)), it would be nice to mention them as a preferred installation method.