### PR TITLE
PulseObject: Add channel_map attribute with raw position integers

### DIFF
--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -157,6 +157,7 @@ class PulseObject(object):
 					None if not struct.active_port else cls_port(struct.active_port.contents) )
 			if hasattr(struct, 'channel_map'):
 				self.channel_count, self.channel_list = struct.channel_map.channels, list()
+				self.channel_map = struct.channel_map.map[:self.channel_count]
 				if self.channel_count > 0:
 					s = c.create_string_buffer(b'\0' * 512)
 					c.pa.channel_map_snprint(s, len(s), struct.channel_map)

--- a/pulsectl/tests/test_with_dummy_instance.py
+++ b/pulsectl/tests/test_with_dummy_instance.py
@@ -509,6 +509,7 @@ class DummyTests(unittest.TestCase):
 			self.assertEqual(sr_dict[sr_name1].volume.value_flat, 0.5)
 			self.assertEqual(sr_dict[sr_name1].mute, 1)
 			self.assertEqual(sr_dict[sr_name1].channel_list, ['mono'])
+			self.assertEqual(sr_dict[sr_name1].channel_map, [0])
 			self.assertIn(sr_name2, sr_dict)
 			self.assertEqual(sr_dict[sr_name2].channel_list, ['mono'])
 
@@ -528,6 +529,7 @@ class DummyTests(unittest.TestCase):
 			self.assertEqual(sr_dict[sr_name1].volume.value_flat, 0.7)
 			self.assertEqual(sr_dict[sr_name1].mute, 0)
 			self.assertEqual(sr_dict[sr_name1].channel_list, ['front-left', 'front-right'])
+			self.assertEqual(sr_dict[sr_name1].channel_map, [1, 2])
 
 			pulse.stream_restore_write(sr_name1, volume=0.4, mode='replace')
 			sr_dict = dict((sr.name, sr) for sr in pulse.stream_restore_list())


### PR DESCRIPTION
This commit adds an attribute `channel_map` to all PulseObject objects that are build from a C struct with a channel_map field, such as PulseSinkInfo or PulseSourceInfo. In contrast to `channel_list`, which is already included with these objects, channel_map is a list of the raw integer position codes from libpulse's `pa_channel_position` enum instead of a string representation of the channel positions.

This is useful to do automated volume calculations, dynamically based on the channel map of a device. In my specific use case, I created additional C bindings for the pa_volume_* functions to separate a multi-channel volume into balance, fade, etc. These methods require a pa_channel_map struct, which can easily be built from the proposed `channel_map` attribute.