### PR TITLE
Fix memory leak in get_peak_sample()

### DIFF
--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -908,6 +908,7 @@ class Pulse(object):
 			try: c.pa.stream_disconnect(s)
 			except c.pa.CallError: pass # stream was removed
 
+		c.pa.stream_unref(s)
 		return min(1.0, samples[0])
 
 	def play_sample(self, name, sink=None, volume=1.0, proplist_str=None):


### PR DESCRIPTION
This PR fixes a memory leak in `get_peak_sample()`. 

## My environment
- Alpine linux 3.14 (using Docker)
  - python 3.9.5
  - pulseaudio 14.2

## How to reproduce
Run below script and check the memory usage of the process. With `master`, the memory usage will continuously increase.
```
#!/usr/bin/env/python

import pulsectl

if __name__ == '__main__':
    with pulsectl.Pulse('test-pulse') as pulse:
        while True:
            pulse.get_peak_sample(source=None, timeout=0.1)
```