### PR TITLE
Expose profile_list for PulseCardPortInfo

### DIFF
--- a/pulsectl/pulsectl.py
+++ b/pulsectl/pulsectl.py
@@ -255,11 +255,13 @@ class PulseCardProfileInfo(PulseObject):
 	c_struct_fields = 'name description n_sinks n_sources priority available'
 
 class PulseCardPortInfo(PulsePortInfo):
-	c_struct_fields = 'name description available priority direction latency_offset'
+	c_struct_fields = 'name description available priority direction latency_offset n_profiles'
 
 	def _init_from_struct(self, struct):
 		super(PulseCardPortInfo, self)._init_from_struct(struct)
 		self.direction = PulseDirectionEnum._c_val(struct.direction)
+		self.profile_list = list(
+			PulseCardProfileInfo(struct.profiles2[n][0]) for n in range(self.n_profiles) )
 
 class PulseCardInfo(PulseObject):
 	c_struct_fields = 'name index driver owner_module n_profiles'


### PR DESCRIPTION
Hi! This is a small pull that exposes the profile list for card's ports. Most of the work was already done, I just did a final push to include the data.

Ports have a list of associated profiles:
```
$ pactl list cards
Card #53
	Name: alsa_card.pci-0000_07_00.1
	[...]
	Active Profile: output:hdmi-stereo-extra1
	Ports:
		[...]
		hdmi-output-1: HDMI / DisplayPort 2 (type: HDMI, priority: 5800, latency offset: 0 usec, availability group: Legacy 2, available)
			Properties:
				port.type = "hdmi"
				port.availability-group = "Legacy 2"
				device.icon_name = "video-display"
				card.profile.port = "1"
				device.product.name = "DELL S2522HG"
			Part of profile(s): output:hdmi-stereo-extra1 <==
[...]
```
With this data exposed, I could grab the name of currently active output with a dumb enumeration like this, which will return "DELL S2522HG" for me:
```python
def get_output_device_raw(pulse: pulsectl.Pulse) -> str:
    for card in pulse.card_list():
        if card.profile_active.name.startswith("output:"):
            for port in card.port_list:
                for profile in port.profile_list:
                    if profile.name == card.profile_active.name:
                        return port.proplist["device.product.name"]
```
